### PR TITLE
Add PublicKey to "InternalsVisibleTo" assemblies in MonoDevelop.TextE…

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/MonoDevelop.TextEditor.csproj
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/MonoDevelop.TextEditor.csproj
@@ -10,8 +10,12 @@
     <DefineConstants Condition="$(OS) == 'Windows_NT'">$(DefineConstants);WINDOWS;WIN32</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="MonoDevelop.TextEditor.Cocoa" />
-    <InternalsVisibleTo Include="MonoDevelop.TextEditor.Wpf" />
+    <!-- Add PublicKey to "InternalsVisibleTo" assemblies below in order to build with msbuild versions >= 16.9.0 -->
+    <!-- This Key is extracted from main/external/mono-addins/mono-addins.snk (within the MonoDevelop solution) -->
+    <InternalsVisibleTo Include="MonoDevelop.TextEditor.Cocoa,
+ PublicKey=002400000480000094000000060200000024000052534131000400000100010079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d04062447c37e0e68c080536fcf3c3fbe2ff9c979ce998475e506e8ce82dd5b0f350dc10e93bf2eeecf874b24770c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d15069089380284dbdd35f46cdff12a1bd78e4ef0065d016df" />
+    <InternalsVisibleTo Include="MonoDevelop.TextEditor.Wpf,
+	PublicKey=002400000480000094000000060200000024000052534131000400000100010079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d04062447c37e0e68c080536fcf3c3fbe2ff9c979ce998475e506e8ce82dd5b0f350dc10e93bf2eeecf874b24770c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d15069089380284dbdd35f46cdff12a1bd78e4ef0065d016df" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationCore" />
     <ProjectReference Include="..\..\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.csproj" Private="false" />


### PR DESCRIPTION
…ditor.csproj

It seems that msbuild 16.9.0 and 16.10.1 (the latest releases) enforce the requirement to specify a public key for assemblies to which "InternalsVisibleTo" declarations are made.  This now needs to be done by MonoDevelop.TextEditor for assemblies MonoDevelop.TextEditor.Wpf and MonoDevelop.TextEditor.Cocoa.  This commit fixes the build for msbuild versions 16.9.0 and 16.10.1