### PR TITLE
Extend menu limits to allow net5.0 projects to be selected

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
@@ -33,6 +33,7 @@ namespace MonoDevelop.DotNetCore.Templating
 {
 	class DotNetCoreProjectTemplateWizard : TemplateWizard
 	{
+		const string defaultParameterNetCore50 = "UseNetCore50";
 		const string defaultParameterNetCore30 = "UseNetCore30";
 		const string defaultParameterNetCore20 = "UseNetCore20";
 		const string defaultParameterNetCore1x = "UseNetCore1x";

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.DotNetCore
 			"2.1", "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0"
 		};
 		static string [] supportedNetCoreAppVersions = {
-			"3.1", "3.0", "2.2", "2.1", "2.0", "1.1", "1.0"
+			"6.0", "5.0", "3.1", "3.0", "2.2", "2.1", "2.0", "1.1", "1.0"
 		};
 
 		public IEnumerable<TargetFramework> GetKnownFrameworks ()
@@ -133,7 +133,9 @@ namespace MonoDevelop.DotNetCore
 
 		public static IEnumerable<TargetFramework> GetNetCoreAppTargetFrameworksWithSdkSupport ()
 		{
-			foreach (var runtimeVersion in GetMajorRuntimeVersions ()) {
+			// explicitly evaluate runtimes list for help during debugging
+			var runtimes = GetMajorRuntimeVersions ();
+			foreach (var runtimeVersion in runtimes) {
 				// In DotNetCore version 2.1 and above the Runtime always ships in an Sdk with the same Major.Minor version. For older versions, this 
 				// rule does not apply, but as these versions have been deprecated we will not worry about explicit filtering support here as this
 				// may cause regressions.
@@ -155,8 +157,10 @@ namespace MonoDevelop.DotNetCore
 
 		static TargetFramework CreateTargetFramework (string identifier, string version)
 		{
+			// evaluate moniker explicitly to help with debugging
 			var moniker = new TargetFrameworkMoniker (identifier, version);
-			return Runtime.SystemAssemblyService.GetTargetFramework (moniker);
+			var targetFramework = Runtime.SystemAssemblyService.GetTargetFramework (moniker);
+			return targetFramework;
 		}
 
 		IEnumerable<TargetFramework> GetNetFrameworkTargetFrameworks ()

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -36,7 +36,7 @@ namespace MonoDevelop.DotNetCore
 	public static class DotNetCoreSdk
 	{
 		static readonly Version DotNetCoreVersion2_1 = new Version (2, 1, 0);
-		internal static readonly DotNetCoreVersion DotNetCoreUnsupportedTargetFrameworkVersion = new DotNetCoreVersion (3, 2, 0);
+		internal static readonly DotNetCoreVersion DotNetCoreUnsupportedTargetFrameworkVersion = new DotNetCoreVersion (6, 1, 0);
 
 		static DotNetCoreSdk ()
 		{

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
@@ -96,8 +96,15 @@ namespace MonoDevelop.DotNetCore
 
 		public static string GetDisplayName (this TargetFramework framework)
 		{
-			if (framework.IsNetCoreApp ())
-				return string.Format (".NET Core {0}", framework.Id.Version);
+			DotNetCoreVersion.TryParse (framework.Id.Version, out DotNetCoreVersion version);
+			if (framework.IsNetCoreApp ()) {
+				// Display shortened framework names for .net5.0 and above in NewProject dialog 
+				if (version.Major >= 5) {
+					return string.Format (".net {0}", framework.Id.Version);
+				} else { 
+				    return string.Format (".NET Core {0}", framework.Id.Version);
+				}
+			}
 
 			if (framework.IsNetStandard ())
 				return string.Format (".NET Standard {0}", framework.Id.Version);


### PR DESCRIPTION
Extend menu limits for NETCoreApp projects so that net5.0+ TargetFrameworks can be created.   

This also updates the `TargetFrameworkMoniker.GetShortFrameworkIdentifier` code so that netcoreapp2.1/3.1 differ from net5.0/6.0+ (see https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks).

Note that although this allows net5.0+ projects to be *selected*, these do not currently work (see Issue #75)

