### PR TITLE
Update document 'Building.md' for net6.0 installed

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -109,8 +109,10 @@ Set the environment variable `MSBuildEnableWorkloadResolver=false` prior to star
 
 eg, in a terminal, before starting dotdevelop as above...   
   
-    export MSBuildEnableWorkloadResolver=false
-    mono ./main/build/bin/MonoDevelop.exe --no-redirect 
+```bash
+export MSBuildEnableWorkloadResolver=false
+mono ./main/build/bin/MonoDevelop.exe --no-redirect 
+```
 
 ## References
 


### PR DESCRIPTION
@DamianSuess I've recently added this extra section to the [Wiki page](https://github.com/dotdevelop/dotdevelop/wiki/Ubuntu-%28Debian%29) for building Ubuntu.  Are you OK to update your `Building.md` page as well?  

I've noticed recently that Github are going to update their `ubuntu-latest` workflow runner to `22.04 (LTS`).  This shouldn't affect the dotdevelop CI workflow (I think) as we use 20.04 in a container.  However, have you looked at whether dotdevelop will build and run under 22.04 LTS at all?
