### PR TITLE
Draft: comment out some nuget packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,12 +4,12 @@
   <packageSources>
     <add key="fallback" value=".nugetfallback" />
     <add key="Nuget Official" value="https://api.nuget.org/v3/index.json" />
-    <!--<add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="NuGetizer3000" value="https://ci.appveyor.com/nuget/nugetizer3000" />-->
+    <add key="NuGetizer3000" value="https://ci.appveyor.com/nuget/nugetizer3000" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,12 +4,12 @@
   <packageSources>
     <add key="fallback" value=".nugetfallback" />
     <add key="Nuget Official" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <!--<add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="NuGetizer3000" value="https://ci.appveyor.com/nuget/nugetizer3000" />
+    <add key="NuGetizer3000" value="https://ci.appveyor.com/nuget/nugetizer3000" />-->
   </packageSources>
 </configuration>

--- a/main/msbuild/ReferencesVSEditor.Windows.props
+++ b/main/msbuild/ReferencesVSEditor.Windows.props
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="$(NuGetVersionRoslyn)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(NuGetVersionVSEditor)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
     <PackageReference Include="Microsoft.VisualStudio.InteractiveWindow" Version="2.8.0" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost" Version="$(NuGetVersionRoslyn)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
+    <!--<PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost" Version="$(NuGetVersionRoslyn)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />-->
   </ItemGroup>
 
   <!-- The consolidated package is authored in a way to avoid adding it to the C# compiler (ref\net46 is empty).
@@ -25,9 +25,9 @@
     <Reference Include="$(NuGetPackageRoot)Microsoft.VisualStudio.Platform.VSEditor\$(NuGetVersionVSEditor)\lib\net472\Microsoft.VisualStudio.Platform.VSEditor.dll">
       <Private>false</Private>
     </Reference>
-    <Reference Include="$(NuGetPackageRoot)Microsoft.CodeAnalysis.InteractiveHost\$(NuGetVersionRoslyn)\lib\net472\Microsoft.CodeAnalysis.InteractiveHost.dll">
+    <!--<Reference Include="$(NuGetPackageRoot)Microsoft.CodeAnalysis.InteractiveHost\$(NuGetVersionRoslyn)\lib\net472\Microsoft.CodeAnalysis.InteractiveHost.dll">
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
-    </Reference>
+    </Reference>-->
   </ItemGroup>
 
 </Project>

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormatter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormatter.cs
@@ -47,7 +47,7 @@ using MonoDevelop.Projects.Policies;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Options;
 using MonoDevelop.CSharp.OptionProvider;
-using Microsoft.VisualStudio.CodingConventions;
+//using Microsoft.VisualStudio.CodingConventions;
 using System.Linq;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
@@ -144,13 +144,13 @@ namespace MonoDevelop.CSharp.Formatting
 			var optionSet = policy.CreateOptions (textPolicy);
 
 			if (input is IReadonlyTextDocument doc) {
-				try {
-					var conventions = EditorConfigService.GetEditorConfigContext (doc.FileName).WaitAndGetResult ();
-					if (conventions != null)
-						optionSet = new FormattingDocumentOptionSet (optionSet, new DocumentOptions (optionSet, conventions.CurrentConventions));
-				} catch (Exception e) {
-					LoggingService.LogError ("Error while loading coding conventions.", e);
-				}
+				// try {
+				// 	var conventions = EditorConfigService.GetEditorConfigContext (doc.FileName).WaitAndGetResult ();
+				// 	if (conventions != null)
+				// 		optionSet = new FormattingDocumentOptionSet (optionSet, new DocumentOptions (optionSet, conventions.CurrentConventions));
+				// } catch (Exception e) {
+				// 	LoggingService.LogError ("Error while loading coding conventions.", e);
+				// }
 			}
 
 			return new StringTextSource (FormatText (optionSet, input.Text, startOffset, startOffset + length));
@@ -159,41 +159,41 @@ namespace MonoDevelop.CSharp.Formatting
 		sealed class DocumentOptions : IDocumentOptions
 		{
 			readonly OptionSet optionSet;
-			readonly ICodingConventionsSnapshot codingConventionsSnapshot;
+			//readonly ICodingConventionsSnapshot codingConventionsSnapshot;
 			private static readonly ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> s_convertedDictionaryCache =
 				new ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> ();
 
 
-			public DocumentOptions (OptionSet optionSet, ICodingConventionsSnapshot codingConventionsSnapshot)
-			{
-				this.optionSet = optionSet;
-				this.codingConventionsSnapshot = codingConventionsSnapshot;
-			}
+			// public DocumentOptions (OptionSet optionSet, ICodingConventionsSnapshot codingConventionsSnapshot)
+			// {
+			// 	this.optionSet = optionSet;
+			// 	this.codingConventionsSnapshot = codingConventionsSnapshot;
+			// }
 
 			public bool TryGetDocumentOption (OptionKey option, out object value)
 			{
-				if (codingConventionsSnapshot != null) {
-					var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
-					if (editorConfigPersistence != null) {
-						// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
-						// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
-						// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
-						// Dictionary<string, object> from the old system.
-						//
-						// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
-						// that the instance doesn't regularly change and thus can be used for further caching
-						var allRawConventions = s_convertedDictionaryCache.GetValue (
-							codingConventionsSnapshot.AllRawConventions,
-							d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
+				// if (codingConventionsSnapshot != null) {
+				// 	var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
+				// 	if (editorConfigPersistence != null) {
+				// 		// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
+				// 		// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
+				// 		// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
+				// 		// Dictionary<string, object> from the old system.
+				// 		//
+				// 		// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
+				// 		// that the instance doesn't regularly change and thus can be used for further caching
+				// 		var allRawConventions = s_convertedDictionaryCache.GetValue (
+				// 			codingConventionsSnapshot.AllRawConventions,
+				// 			d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
 
-						try {
-							if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
-								return true;
-						} catch (Exception ex) {
-							LoggingService.LogError ("Error while getting editor config preferences.", ex);
-						}
-					}
-				}
+				// 		try {
+				// 			if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
+				// 				return true;
+				// 		} catch (Exception ex) {
+				// 			LoggingService.LogError ("Error while getting editor config preferences.", ex);
+				// 		}
+				// 	}
+				// }
 
 				var result = optionSet.GetOption (option);
 				value = result;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormatter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormatter.cs
@@ -143,63 +143,63 @@ namespace MonoDevelop.CSharp.Formatting
 			var textPolicy = policyParent.Get<TextStylePolicy> (chain);
 			var optionSet = policy.CreateOptions (textPolicy);
 
-			if (input is IReadonlyTextDocument doc) {
-				// try {
-				// 	var conventions = EditorConfigService.GetEditorConfigContext (doc.FileName).WaitAndGetResult ();
-				// 	if (conventions != null)
-				// 		optionSet = new FormattingDocumentOptionSet (optionSet, new DocumentOptions (optionSet, conventions.CurrentConventions));
-				// } catch (Exception e) {
-				// 	LoggingService.LogError ("Error while loading coding conventions.", e);
-				// }
-			}
+			/* if (input is IReadonlyTextDocument doc) {
+				try {
+					var conventions = EditorConfigService.GetEditorConfigContext (doc.FileName).WaitAndGetResult ();
+					if (conventions != null)
+						optionSet = new FormattingDocumentOptionSet (optionSet, new DocumentOptions (optionSet, conventions.CurrentConventions));
+				} catch (Exception e) {
+					LoggingService.LogError ("Error while loading coding conventions.", e);
+				}
+			} */
 
 			return new StringTextSource (FormatText (optionSet, input.Text, startOffset, startOffset + length));
 		}
 
-		sealed class DocumentOptions : IDocumentOptions
+		/* sealed class DocumentOptions : IDocumentOptions
 		{
 			readonly OptionSet optionSet;
-			//readonly ICodingConventionsSnapshot codingConventionsSnapshot;
+			readonly ICodingConventionsSnapshot codingConventionsSnapshot;
 			private static readonly ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> s_convertedDictionaryCache =
 				new ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> ();
 
 
-			// public DocumentOptions (OptionSet optionSet, ICodingConventionsSnapshot codingConventionsSnapshot)
-			// {
-			// 	this.optionSet = optionSet;
-			// 	this.codingConventionsSnapshot = codingConventionsSnapshot;
-			// }
-
-			public bool TryGetDocumentOption (OptionKey option, out object value)
+			 public DocumentOptions (OptionSet optionSet, ICodingConventionsSnapshot codingConventionsSnapshot)
 			{
-				// if (codingConventionsSnapshot != null) {
-				// 	var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
-				// 	if (editorConfigPersistence != null) {
-				// 		// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
-				// 		// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
-				// 		// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
-				// 		// Dictionary<string, object> from the old system.
-				// 		//
-				// 		// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
-				// 		// that the instance doesn't regularly change and thus can be used for further caching
-				// 		var allRawConventions = s_convertedDictionaryCache.GetValue (
-				// 			codingConventionsSnapshot.AllRawConventions,
-				// 			d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
+				this.optionSet = optionSet;
+				this.codingConventionsSnapshot = codingConventionsSnapshot;
+			}
 
-				// 		try {
-				// 			if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
-				// 				return true;
-				// 		} catch (Exception ex) {
-				// 			LoggingService.LogError ("Error while getting editor config preferences.", ex);
-				// 		}
-				// 	}
-				// }
+			 public bool TryGetDocumentOption (OptionKey option, out object value)
+			{
+				if (codingConventionsSnapshot != null) {
+					var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
+					if (editorConfigPersistence != null) {
+						// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
+						// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
+						// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
+						// Dictionary<string, object> from the old system.
+						//
+						// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
+						// that the instance doesn't regularly change and thus can be used for further caching
+						var allRawConventions = s_convertedDictionaryCache.GetValue (
+							codingConventionsSnapshot.AllRawConventions,
+							d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
+
+						try {
+							if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
+								return true;
+						} catch (Exception ex) {
+							LoggingService.LogError ("Error while getting editor config preferences.", ex);
+						}
+					}
+				}
 
 				var result = optionSet.GetOption (option);
 				value = result;
 				return true;
-			}
-		}
+			} 
+		} */
 
 		sealed class FormattingDocumentOptionSet : OptionSet
 		{

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/CSharpDocumentOptionsProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/CSharpDocumentOptionsProvider.cs
@@ -34,7 +34,7 @@ using MonoDevelop.CSharp.Formatting;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Projects.Policies;
-using Microsoft.VisualStudio.CodingConventions;
+//using Microsoft.VisualStudio.CodingConventions;
 using System.IO;
 using MonoDevelop.Core;
 using System.Linq;
@@ -45,113 +45,113 @@ using System.Runtime.CompilerServices;
 
 namespace MonoDevelop.CSharp.OptionProvider
 {
-	class CSharpDocumentOptionsProvider : IDocumentOptionsProvider
-	{
-		async Task<IDocumentOptions> IDocumentOptionsProvider.GetOptionsForDocumentAsync (Document document, CancellationToken cancellationToken)
-		{
-			var mdws = document.Project.Solution.Workspace as MonoDevelopWorkspace;
-			var project = mdws?.GetMonoProject (document.Project.Id);
+	//class CSharpDocumentOptionsProvider : IDocumentOptionsProvider
+	//{
+		// async Task<IDocumentOptions> IDocumentOptionsProvider.GetOptionsForDocumentAsync (Document document, CancellationToken cancellationToken)
+		// {
+		// 	var mdws = document.Project.Solution.Workspace as MonoDevelopWorkspace;
+		// 	var project = mdws?.GetMonoProject (document.Project.Id);
 
-			var path = GetPath (document);
-			ICodingConventionContext conventions = null;
-			try {
-				if (path != null)
-					conventions = await EditorConfigService.GetEditorConfigContext (path, cancellationToken);
-			} catch (Exception e) {
-				LoggingService.LogError("Error while loading coding conventions.", e);
-			}
-			return new DocumentOptions (project?.Policies, conventions?.CurrentConventions);
-		}
+		// 	var path = GetPath (document);
+		// 	//ICodingConventionContext conventions = null;
+		// 	// try {
+		// 	// 	if (path != null)
+		// 	// 		//conventions = await EditorConfigService.GetEditorConfigContext (path, cancellationToken);
+		// 	// } catch (Exception e) {
+		// 	// 	LoggingService.LogError("Error while loading coding conventions.", e);
+		// 	// }
+		// 	//return new DocumentOptions (project?.Policies, conventions?.CurrentConventions);
+		// }
 
-		static string GetPath(Document document)
-		{
-			if (document.FilePath != null)
-				return document.FilePath;
+		// static string GetPath(Document document)
+		// {
+		// 	if (document.FilePath != null)
+		// 		return document.FilePath;
 
-			// The file might not actually have a path yet, if it's a file being proposed by a code action. We'll guess a file path to use
-			if (document.Name != null && document.Project.FilePath != null) {
-				return Path.Combine (Path.GetDirectoryName (document.Project.FilePath), document.Name);
-			}
+		// 	// The file might not actually have a path yet, if it's a file being proposed by a code action. We'll guess a file path to use
+		// 	if (document.Name != null && document.Project.FilePath != null) {
+		// 		return Path.Combine (Path.GetDirectoryName (document.Project.FilePath), document.Name);
+		// 	}
 
-			// Really no idea where this is going, so bail
-			return null;
-		}
+		// 	// Really no idea where this is going, so bail
+		// 	return null;
+		// }
 
-		internal class DocumentOptions : IDocumentOptions
-		{
-			readonly static IEnumerable<string> types = Ide.IdeServices.DesktopService.GetMimeTypeInheritanceChain (CSharpFormatter.MimeType);
-			readonly PolicyBag policyBag;
+		//internal class DocumentOptions : IDocumentOptions
+		//{
+			//readonly static IEnumerable<string> types = Ide.IdeServices.DesktopService.GetMimeTypeInheritanceChain (CSharpFormatter.MimeType);
+			//readonly PolicyBag policyBag;
 
-			CSharpFormattingPolicy policy;
-			CSharpFormattingPolicy Policy => policy ?? (policy = policyBag?.Get<CSharpFormattingPolicy> (types) ?? PolicyService.InvariantPolicies.Get<CSharpFormattingPolicy> (types));
+			//CSharpFormattingPolicy policy;
+			//CSharpFormattingPolicy Policy => policy ?? (policy = policyBag?.Get<CSharpFormattingPolicy> (types) ?? PolicyService.InvariantPolicies.Get<CSharpFormattingPolicy> (types));
 
-			TextStylePolicy textpolicy;
-			TextStylePolicy TextPolicy => textpolicy ?? (textpolicy = policyBag?.Get<TextStylePolicy> (types) ?? PolicyService.InvariantPolicies?.Get<TextStylePolicy> (types));
+			//TextStylePolicy textpolicy;
+			//TextStylePolicy TextPolicy => textpolicy ?? (textpolicy = policyBag?.Get<TextStylePolicy> (types) ?? PolicyService.InvariantPolicies?.Get<TextStylePolicy> (types));
 
-			readonly ICodingConventionsSnapshot codingConventionsSnapshot;
-			private static readonly ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> s_convertedDictionaryCache =
-				new ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> ();
+			//readonly ICodingConventionsSnapshot codingConventionsSnapshot;
+			//private static readonly ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> s_convertedDictionaryCache =
+			//	new ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> ();
 
-			public DocumentOptions (PolicyBag policyBag, ICodingConventionsSnapshot codingConventionsSnapshot)
-			{
-				this.policyBag = policyBag;
-				this.codingConventionsSnapshot = codingConventionsSnapshot;
-			}
+			// public DocumentOptions (PolicyBag policyBag, ICodingConventionsSnapshot codingConventionsSnapshot)
+			// {
+			// 	this.policyBag = policyBag;
+			// 	this.codingConventionsSnapshot = codingConventionsSnapshot;
+			// }
 
-			public bool TryGetDocumentOption (OptionKey option, out object value)
-			{
-				if (codingConventionsSnapshot != null) {
-					var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
-					if (editorConfigPersistence != null) {
-						// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
-						// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
-						// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
-						// Dictionary<string, object> from the old system.
-						//
-						// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
-						// that the instance doesn't regularly change and thus can be used for further caching
-						var allRawConventions = s_convertedDictionaryCache.GetValue (
-							codingConventionsSnapshot.AllRawConventions,
-							d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
+		// 	public bool TryGetDocumentOption (OptionKey option, out object value)
+		// 	{
+		// 		if (codingConventionsSnapshot != null) {
+		// 			var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
+		// 			if (editorConfigPersistence != null) {
+		// 				// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
+		// 				// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
+		// 				// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
+		// 				// Dictionary<string, object> from the old system.
+		// 				//
+		// 				// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
+		// 				// that the instance doesn't regularly change and thus can be used for further caching
+		// 				var allRawConventions = s_convertedDictionaryCache.GetValue (
+		// 					codingConventionsSnapshot.AllRawConventions,
+		// 					d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
 
-						try {
-							if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
-								return true;
-						} catch (Exception ex) {
-							LoggingService.LogError ("Error while getting editor config preferences.", ex);
-						}
-					}
-				}
+		// 				try {
+		// 					if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
+		// 						return true;
+		// 				} catch (Exception ex) {
+		// 					LoggingService.LogError ("Error while getting editor config preferences.", ex);
+		// 				}
+		// 			}
+		// 		}
 
-				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize) {
-					value = TextPolicy.IndentWidth;
-					return true;
-				}
+		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize) {
+		// 			value = TextPolicy.IndentWidth;
+		// 			return true;
+		// 		}
 
-				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine) {
-					value = TextPolicy.GetEolMarker ();
-					return true;
-				}
+		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine) {
+		// 			value = TextPolicy.GetEolMarker ();
+		// 			return true;
+		// 		}
 
-				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.SmartIndent) {
-					value = Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentStyle.Smart;
-					return true;
-				}
+		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.SmartIndent) {
+		// 			value = Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentStyle.Smart;
+		// 			return true;
+		// 		}
 
-				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize) {
-					value = TextPolicy.TabWidth;
-					return true;
-				}
+		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize) {
+		// 			value = TextPolicy.TabWidth;
+		// 			return true;
+		// 		}
 
-				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs) {
-					value = !TextPolicy.TabsToSpaces;
-					return true;
-				}
+		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs) {
+		// 			value = !TextPolicy.TabsToSpaces;
+		// 			return true;
+		// 		}
 
-				var result = Policy.OptionSet.GetOption (option);
-				value = result;
-				return true;
-			}
-		}
-	}
+		// 		var result = Policy.OptionSet.GetOption (option);
+		// 		value = result;
+		// 		return true;
+		// 	}
+		// }
+	//}
 }

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/CSharpDocumentOptionsProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/CSharpDocumentOptionsProvider.cs
@@ -23,7 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
+/* using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,7 +34,7 @@ using MonoDevelop.CSharp.Formatting;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Projects.Policies;
-//using Microsoft.VisualStudio.CodingConventions;
+using Microsoft.VisualStudio.CodingConventions;
 using System.IO;
 using MonoDevelop.Core;
 using System.Linq;
@@ -45,113 +45,114 @@ using System.Runtime.CompilerServices;
 
 namespace MonoDevelop.CSharp.OptionProvider
 {
-	//class CSharpDocumentOptionsProvider : IDocumentOptionsProvider
-	//{
-		// async Task<IDocumentOptions> IDocumentOptionsProvider.GetOptionsForDocumentAsync (Document document, CancellationToken cancellationToken)
-		// {
-		// 	var mdws = document.Project.Solution.Workspace as MonoDevelopWorkspace;
-		// 	var project = mdws?.GetMonoProject (document.Project.Id);
+	class CSharpDocumentOptionsProvider : IDocumentOptionsProvider
+	{
+		async Task<IDocumentOptions> IDocumentOptionsProvider.GetOptionsForDocumentAsync (Document document, CancellationToken cancellationToken)
+		{
+			var mdws = document.Project.Solution.Workspace as MonoDevelopWorkspace;
+			var project = mdws?.GetMonoProject (document.Project.Id);
 
-		// 	var path = GetPath (document);
-		// 	//ICodingConventionContext conventions = null;
-		// 	// try {
-		// 	// 	if (path != null)
-		// 	// 		//conventions = await EditorConfigService.GetEditorConfigContext (path, cancellationToken);
-		// 	// } catch (Exception e) {
-		// 	// 	LoggingService.LogError("Error while loading coding conventions.", e);
-		// 	// }
-		// 	//return new DocumentOptions (project?.Policies, conventions?.CurrentConventions);
-		// }
+			var path = GetPath (document);
+			ICodingConventionContext conventions = null;
+			 try {
+			 	if (path != null)
+			 		//conventions = await EditorConfigService.GetEditorConfigContext (path, cancellationToken);
+			 } catch (Exception e) {
+			 	LoggingService.LogError("Error while loading coding conventions.", e);
+			 }
+			return new DocumentOptions (project?.Policies, conventions?.CurrentConventions);
+		}
 
-		// static string GetPath(Document document)
-		// {
-		// 	if (document.FilePath != null)
-		// 		return document.FilePath;
+		static string GetPath(Document document)
+		{
+			if (document.FilePath != null)
+				return document.FilePath;
 
-		// 	// The file might not actually have a path yet, if it's a file being proposed by a code action. We'll guess a file path to use
-		// 	if (document.Name != null && document.Project.FilePath != null) {
-		// 		return Path.Combine (Path.GetDirectoryName (document.Project.FilePath), document.Name);
-		// 	}
+			// The file might not actually have a path yet, if it's a file being proposed by a code action. We'll guess a file path to use
+			if (document.Name != null && document.Project.FilePath != null) {
+				return Path.Combine (Path.GetDirectoryName (document.Project.FilePath), document.Name);
+			}
 
-		// 	// Really no idea where this is going, so bail
-		// 	return null;
-		// }
+			// Really no idea where this is going, so bail
+			return null;
+		}
 
-		//internal class DocumentOptions : IDocumentOptions
-		//{
-			//readonly static IEnumerable<string> types = Ide.IdeServices.DesktopService.GetMimeTypeInheritanceChain (CSharpFormatter.MimeType);
-			//readonly PolicyBag policyBag;
+		internal class DocumentOptions : IDocumentOptions
+		{
+			readonly static IEnumerable<string> types = Ide.IdeServices.DesktopService.GetMimeTypeInheritanceChain (CSharpFormatter.MimeType);
+			readonly PolicyBag policyBag;
 
-			//CSharpFormattingPolicy policy;
-			//CSharpFormattingPolicy Policy => policy ?? (policy = policyBag?.Get<CSharpFormattingPolicy> (types) ?? PolicyService.InvariantPolicies.Get<CSharpFormattingPolicy> (types));
+			CSharpFormattingPolicy policy;
+			CSharpFormattingPolicy Policy => policy ?? (policy = policyBag?.Get<CSharpFormattingPolicy> (types) ?? PolicyService.InvariantPolicies.Get<CSharpFormattingPolicy> (types));
 
-			//TextStylePolicy textpolicy;
-			//TextStylePolicy TextPolicy => textpolicy ?? (textpolicy = policyBag?.Get<TextStylePolicy> (types) ?? PolicyService.InvariantPolicies?.Get<TextStylePolicy> (types));
+			TextStylePolicy textpolicy;
+			TextStylePolicy TextPolicy => textpolicy ?? (textpolicy = policyBag?.Get<TextStylePolicy> (types) ?? PolicyService.InvariantPolicies?.Get<TextStylePolicy> (types));
 
-			//readonly ICodingConventionsSnapshot codingConventionsSnapshot;
-			//private static readonly ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> s_convertedDictionaryCache =
-			//	new ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> ();
+			readonly ICodingConventionsSnapshot codingConventionsSnapshot;
+			private static readonly ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> s_convertedDictionaryCache =
+				new ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> ();
 
-			// public DocumentOptions (PolicyBag policyBag, ICodingConventionsSnapshot codingConventionsSnapshot)
-			// {
-			// 	this.policyBag = policyBag;
-			// 	this.codingConventionsSnapshot = codingConventionsSnapshot;
-			// }
+			public DocumentOptions (PolicyBag policyBag, ICodingConventionsSnapshot codingConventionsSnapshot)
+			{
+				this.policyBag = policyBag;
+				this.codingConventionsSnapshot = codingConventionsSnapshot;
+			}
 
-		// 	public bool TryGetDocumentOption (OptionKey option, out object value)
-		// 	{
-		// 		if (codingConventionsSnapshot != null) {
-		// 			var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
-		// 			if (editorConfigPersistence != null) {
-		// 				// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
-		// 				// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
-		// 				// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
-		// 				// Dictionary<string, object> from the old system.
-		// 				//
-		// 				// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
-		// 				// that the instance doesn't regularly change and thus can be used for further caching
-		// 				var allRawConventions = s_convertedDictionaryCache.GetValue (
-		// 					codingConventionsSnapshot.AllRawConventions,
-		// 					d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
+			public bool TryGetDocumentOption (OptionKey option, out object value)
+			{
+				if (codingConventionsSnapshot != null) {
+					var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
+					if (editorConfigPersistence != null) {
+						// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
+						// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
+						// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
+						// Dictionary<string, object> from the old system.
+						//
+						// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
+						// that the instance doesn't regularly change and thus can be used for further caching
+						var allRawConventions = s_convertedDictionaryCache.GetValue (
+							codingConventionsSnapshot.AllRawConventions,
+							d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
 
-		// 				try {
-		// 					if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
-		// 						return true;
-		// 				} catch (Exception ex) {
-		// 					LoggingService.LogError ("Error while getting editor config preferences.", ex);
-		// 				}
-		// 			}
-		// 		}
+						try {
+							if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
+								return true;
+						} catch (Exception ex) {
+							LoggingService.LogError ("Error while getting editor config preferences.", ex);
+						}
+					}
+				}
 
-		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize) {
-		// 			value = TextPolicy.IndentWidth;
-		// 			return true;
-		// 		}
+				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentationSize) {
+					value = TextPolicy.IndentWidth;
+					return true;
+				}
 
-		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine) {
-		// 			value = TextPolicy.GetEolMarker ();
-		// 			return true;
-		// 		}
+				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.NewLine) {
+					value = TextPolicy.GetEolMarker ();
+					return true;
+				}
 
-		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.SmartIndent) {
-		// 			value = Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentStyle.Smart;
-		// 			return true;
-		// 		}
+				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.SmartIndent) {
+					value = Microsoft.CodeAnalysis.Formatting.FormattingOptions.IndentStyle.Smart;
+					return true;
+				}
 
-		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize) {
-		// 			value = TextPolicy.TabWidth;
-		// 			return true;
-		// 		}
+				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.TabSize) {
+					value = TextPolicy.TabWidth;
+					return true;
+				}
 
-		// 		if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs) {
-		// 			value = !TextPolicy.TabsToSpaces;
-		// 			return true;
-		// 		}
+				if (option.Option == Microsoft.CodeAnalysis.Formatting.FormattingOptions.UseTabs) {
+					value = !TextPolicy.TabsToSpaces;
+					return true;
+				}
 
-		// 		var result = Policy.OptionSet.GetOption (option);
-		// 		value = result;
-		// 		return true;
-		// 	}
-		// }
-	//}
+				var result = Policy.OptionSet.GetOption (option);
+				value = result;
+				return true;
+			}
+		}
+	}
 }
+ */

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/OptionProviderFactory.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/OptionProviderFactory.cs
@@ -23,19 +23,20 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
+/* using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Options;
 
 namespace MonoDevelop.CSharp.OptionProvider
 {
-	// [Export (typeof (IDocumentOptionsProviderFactory))]
-	// class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
-	// {
-	// 	// public IDocumentOptionsProvider TryCreate (Workspace workspace)
-	// 	// {
-	// 	// 	return new CSharpDocumentOptionsProvider ();
-	// 	// }
-	// }
+	[Export (typeof (IDocumentOptionsProviderFactory))]
+	class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
+	{
+		public IDocumentOptionsProvider TryCreate (Workspace workspace)
+		{
+			return new CSharpDocumentOptionsProvider ();
+		}
+	}
 }
+ */

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/OptionProviderFactory.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/OptionProviderFactory.cs
@@ -30,12 +30,12 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace MonoDevelop.CSharp.OptionProvider
 {
-	[Export (typeof (IDocumentOptionsProviderFactory))]
-	class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
-	{
-		public IDocumentOptionsProvider TryCreate (Workspace workspace)
-		{
-			return new CSharpDocumentOptionsProvider ();
-		}
-	}
+	// [Export (typeof (IDocumentOptionsProviderFactory))]
+	// class EditorConfigDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
+	// {
+	// 	// public IDocumentOptionsProvider TryCreate (Workspace workspace)
+	// 	// {
+	// 	// 	return new CSharpDocumentOptionsProvider ();
+	// 	// }
+	// }
 }

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -249,11 +249,11 @@ namespace MonoDevelop.TextEditor
 
 			warnOverwrite = false;
 
-			// if (editorConfigContext != null) {
-			// 	editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
-			// 	EditorConfigService.RemoveEditConfigContext (TextDocument.FilePath).Ignore ();
-			// 	editorConfigContext = null;
-			// }
+			/* if (editorConfigContext != null) {
+				editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
+				EditorConfigService.RemoveEditConfigContext (TextDocument.FilePath).Ignore ();
+				editorConfigContext = null;
+			} */
 
 			if (FilePath != TextDocument.FilePath && !string.IsNullOrEmpty (TextDocument.FilePath))
 				AutoSave.RemoveAutoSaveFile (TextDocument.FilePath);
@@ -312,12 +312,12 @@ namespace MonoDevelop.TextEditor
 
 			UnsubscribeFromEvents ();
 
-			//if (policyContainer != null)
-			//	policyContainer.PolicyChanged -= PolicyChanged;
-			//if (editorConfigContext != null) {
-				//editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
-				//EditorConfigService.RemoveEditConfigContext (FilePath).Ignore ();
-			//}
+			/* if (policyContainer != null)
+				policyContainer.PolicyChanged -= PolicyChanged;
+			if (editorConfigContext != null) {
+				editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
+				EditorConfigService.RemoveEditConfigContext (FilePath).Ignore ();
+			} */
 
 			base.OnDispose ();
 		}
@@ -362,38 +362,38 @@ namespace MonoDevelop.TextEditor
 				sourceEditorOptions.ShowLineNumberMargin);
 		}
 
-		// void UpdateTextEditorOptions (object sender, EventArgs e)
-		// {
-		// 	UpdateTextEditorOptionsAsync ().Forget ();
-		// }
+		/* void UpdateTextEditorOptions (object sender, EventArgs e)
+		{
+			UpdateTextEditorOptionsAsync ().Forget ();
+		}
 
-		// async Task UpdateTextEditorOptionsAsync ()
-		// {
-		// 	UpdateLineNumberMarginOption ();
+		async Task UpdateTextEditorOptionsAsync ()
+		{
+			UpdateLineNumberMarginOption ();
 
-		// 	var foldMargin = PropertyService.Get<bool> ("ShowFoldMargin");
-		// 	Imports.OutliningManagerService.GetOutliningManager (TextView).Enabled = foldMargin;
+			var foldMargin = PropertyService.Get<bool> ("ShowFoldMargin");
+			Imports.OutliningManagerService.GetOutliningManager (TextView).Enabled = foldMargin;
 
-		// 	var newPolicyContainer = (Owner as IPolicyProvider)?.Policies;
-		// 	if (newPolicyContainer != policyContainer) {
-		// 		if (policyContainer != null)
-		// 			policyContainer.PolicyChanged -= PolicyChanged;
-		// 		policyContainer = newPolicyContainer;
-		// 	}
-		// 	if (policyContainer != null)
-		// 		policyContainer.PolicyChanged += PolicyChanged;
+			var newPolicyContainer = (Owner as IPolicyProvider)?.Policies;
+			if (newPolicyContainer != policyContainer) {
+				if (policyContainer != null)
+					policyContainer.PolicyChanged -= PolicyChanged;
+				policyContainer = newPolicyContainer;
+			}
+			if (policyContainer != null)
+				policyContainer.PolicyChanged += PolicyChanged;
 
-		// 	var newEditorConfigContext = await EditorConfigService.GetEditorConfigContext (FilePath, default);
-		// 	if (newEditorConfigContext != editorConfigContext) {
-		// 		if (editorConfigContext != null)
-		// 			editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
-		// 		editorConfigContext = newEditorConfigContext;
-		// 	}
-		// 	if (editorConfigContext != null)
-		// 		editorConfigContext.CodingConventionsChangedAsync += UpdateOptionsFromEditorConfigAsync;
+			var newEditorConfigContext = await EditorConfigService.GetEditorConfigContext (FilePath, default);
+			if (newEditorConfigContext != editorConfigContext) {
+				if (editorConfigContext != null)
+					editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
+				editorConfigContext = newEditorConfigContext;
+			}
+			if (editorConfigContext != null)
+				editorConfigContext.CodingConventionsChangedAsync += UpdateOptionsFromEditorConfigAsync;
 
-		// 	await UpdateOptionsFromEditorConfigAsync (null, null);
-		// }
+			await UpdateOptionsFromEditorConfigAsync (null, null);
+		} */
 
 		void ClearOptionValue(string optionName)
 		{
@@ -438,179 +438,179 @@ namespace MonoDevelop.TextEditor
 #endif
 		}
 
-// 		private Task UpdateOptionsFromEditorConfigAsync (object sender, CodingConventionsChangedEventArgs args)
-// 		{
-// 			// Set base options first, then override with editorconfig values
-// 			UpdateOptionsFromPolicy ();
+/* 		private Task UpdateOptionsFromEditorConfigAsync (object sender, CodingConventionsChangedEventArgs args)
+		{
+			// Set base options first, then override with editorconfig values
+			UpdateOptionsFromPolicy ();
 
-// 			if (editorConfigContext == null)
-// 				return Task.CompletedTask;
+			if (editorConfigContext == null)
+				return Task.CompletedTask;
 
-// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentStyle (out var indentStyle))
-// 				SetOptionValue (DefaultOptions.ConvertTabsToSpacesOptionName, indentStyle == IndentStyle.Spaces);
-// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetTabWidth (out var tabWidth))
-// 				SetOptionValue (DefaultOptions.TabSizeOptionName, tabWidth);
-// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentSize (out var indentSize))
-// 				SetOptionValue (DefaultOptions.IndentSizeOptionName, indentSize);
-// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetLineEnding (out var lineEnding))
-// 				SetOptionValue (DefaultOptions.NewLineCharacterOptionName, lineEnding);
-// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out var allowTrailingWhitespace))
-// 				SetOptionValue (DefaultOptions.TrimTrailingWhiteSpaceOptionName, !allowTrailingWhitespace);
+			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentStyle (out var indentStyle))
+				SetOptionValue (DefaultOptions.ConvertTabsToSpacesOptionName, indentStyle == IndentStyle.Spaces);
+			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetTabWidth (out var tabWidth))
+				SetOptionValue (DefaultOptions.TabSizeOptionName, tabWidth);
+			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentSize (out var indentSize))
+				SetOptionValue (DefaultOptions.IndentSizeOptionName, indentSize);
+			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetLineEnding (out var lineEnding))
+				SetOptionValue (DefaultOptions.NewLineCharacterOptionName, lineEnding);
+			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out var allowTrailingWhitespace))
+				SetOptionValue (DefaultOptions.TrimTrailingWhiteSpaceOptionName, !allowTrailingWhitespace);
 
-// 			var setVerticalRulers = false;
-// 			int [] verticalRulers = null;
+			var setVerticalRulers = false;
+			int [] verticalRulers = null;
 
-// 			// "Show column ruler" preference still needs to be checked, regardless of whether or not editorconfig
-// 			// has a setting for where rulers should appear
-// 			if (PropertyService.Get<bool> ("ShowRuler")) {
-// 				if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.RulersConvention, out var rulers)) {
-// 					setVerticalRulers = true;
-// 					if (!string.IsNullOrEmpty (rulers)) {
-// 						verticalRulers = Array.ConvertAll (rulers.Split (','), val => {
-// 							if (int.TryParse (val, out var col))
-// 								return col;
-// 							return 0;
-// 						});
-// 					}
-// 				} else if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out var maxLineLength)) {
-// 					if (maxLineLength != "off" && int.TryParse (maxLineLength, out var i)) {
-// 						setVerticalRulers = true;
-// 						verticalRulers = new [] { i };
-// 					} else
-// 						setVerticalRulers = false;
-// 				}
-// 			}
+			// "Show column ruler" preference still needs to be checked, regardless of whether or not editorconfig
+			// has a setting for where rulers should appear
+			if (PropertyService.Get<bool> ("ShowRuler")) {
+				if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.RulersConvention, out var rulers)) {
+					setVerticalRulers = true;
+					if (!string.IsNullOrEmpty (rulers)) {
+						verticalRulers = Array.ConvertAll (rulers.Split (','), val => {
+							if (int.TryParse (val, out var col))
+								return col;
+							return 0;
+						});
+					}
+				} else if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out var maxLineLength)) {
+					if (maxLineLength != "off" && int.TryParse (maxLineLength, out var i)) {
+						setVerticalRulers = true;
+						verticalRulers = new [] { i };
+					} else
+						setVerticalRulers = false;
+				}
+			}
 
-// #if !WINDOWS
-// 			if (setVerticalRulers)
-// 				EditorOptions.SetOptionValue (DefaultTextViewOptions.VerticalRulersName, verticalRulers ?? Array.Empty<int> ());
-// #endif
+#if !WINDOWS
+			if (setVerticalRulers)
+				EditorOptions.SetOptionValue (DefaultTextViewOptions.VerticalRulersName, verticalRulers ?? Array.Empty<int> ());
+#endif
 
-// 			return Task.CompletedTask;
-// 		}
+			return Task.CompletedTask;
+		}
 
-// 		private void PolicyChanged (object sender, PolicyChangedEventArgs e)
-// 			=> UpdateTextEditorOptions (sender, e);
+		private void PolicyChanged (object sender, PolicyChangedEventArgs e)
+			=> UpdateTextEditorOptions (sender, e);
 
-// 		protected override object OnGetContent (Type type)
-// 		{
-// 			if (contentProviders != null) {
-// 				foreach (var provider in contentProviders) {
-// 					var content = provider.GetContent (TextView, type);
-// 					if (content != null) {
-// 						return content;
-// 					}
-// 				}
-// 			}
-// 			return GetIntrinsicType (type);
-// 		}
+		protected override object OnGetContent (Type type)
+		{
+			if (contentProviders != null) {
+				foreach (var provider in contentProviders) {
+					var content = provider.GetContent (TextView, type);
+					if (content != null) {
+						return content;
+					}
+				}
+			}
+			return GetIntrinsicType (type);
+		}
 
-// 		protected override IEnumerable<object> OnGetContents (Type type)
-// 		{
-// 			if (contentProviders != null) {
-// 				foreach (var provider in contentProviders) {
-// 					var contents = provider.GetContents (TextView, type);
-// 					if (contents != null) {
-// 						foreach (var content in contents)
-// 							yield return content;
-// 					}
-// 				}
-// 			}
+		protected override IEnumerable<object> OnGetContents (Type type)
+		{
+			if (contentProviders != null) {
+				foreach (var provider in contentProviders) {
+					var contents = provider.GetContents (TextView, type);
+					if (contents != null) {
+						foreach (var content in contents)
+							yield return content;
+					}
+				}
+			}
 
-// 			var intrinsicType = GetIntrinsicType (type);
-// 			if (intrinsicType != null) {
-// 				yield return intrinsicType;
-// 			}
-// 		}
+			var intrinsicType = GetIntrinsicType (type);
+			if (intrinsicType != null) {
+				yield return intrinsicType;
+			}
+		}
 
-// 		object GetIntrinsicType (Type type)
-// 		{
-// 			if (type.IsInstanceOfType (TextBuffer))
-// 				return TextBuffer;
-// 			if (type.IsInstanceOfType (TextDocument))
-// 				return TextDocument;
-// 			if (type.IsInstanceOfType (TextView))
-// 				return TextView;
-// 			if (type.IsInstanceOfType (this))
-// 				return this;
-// 			return null;
-// 		}
+		object GetIntrinsicType (Type type)
+		{
+			if (type.IsInstanceOfType (TextBuffer))
+				return TextBuffer;
+			if (type.IsInstanceOfType (TextDocument))
+				return TextDocument;
+			if (type.IsInstanceOfType (TextView))
+				return TextView;
+			if (type.IsInstanceOfType (this))
+				return this;
+			return null;
+		}
 
-// 		Task Load (bool reloading)
-// 		{
-// 			// We actually load initial content at construction time, so this
-// 			// overload only needs to cover reload and autosave scenarios
+		Task Load (bool reloading)
+		{
+			// We actually load initial content at construction time, so this
+			// overload only needs to cover reload and autosave scenarios
 
-// 			if (warnOverwrite) {
-// 				warnOverwrite = false;
-// 				DismissInfoBar ();
-// 				ShowNotification = false;
-// 			}
+			if (warnOverwrite) {
+				warnOverwrite = false;
+				DismissInfoBar ();
+				ShowNotification = false;
+			}
 
-// 			if (reloading) {
-// 				TextDocument.Reload ();
-// 			} else if (AutoSave.AutoSaveExists (FilePath)) {
-// 				var autosaveContent = AutoSave.LoadAutoSave (FilePath);
+			if (reloading) {
+				TextDocument.Reload ();
+			} else if (AutoSave.AutoSaveExists (FilePath)) {
+				var autosaveContent = AutoSave.LoadAutoSave (FilePath);
 
-// 				MarkDirty ();
-// 				warnOverwrite = true;
+				MarkDirty ();
+				warnOverwrite = true;
 
-// 				// Set editor read-only until user picks one of the above options.
-// 				var setWritable = !TextView.Options.DoesViewProhibitUserInput ();
-// 				if (setWritable)
-// 					TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, true);
+				// Set editor read-only until user picks one of the above options.
+				var setWritable = !TextView.Options.DoesViewProhibitUserInput ();
+				if (setWritable)
+					TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, true);
 
-// 				var (primaryMessageText, secondaryMessageText) = SplitMessageString (
-// 					BrandingService.BrandApplicationName (GettextCatalog.GetString (
-// 						"<b>An autosave file has been found for this file.</b>\n" +
-// 						"This could mean that another instance of MonoDevelop is editing this " +
-// 						"file, or that MonoDevelop crashed with unsaved changes.\n\n" +
-// 						"Do you want to use the original file, or load from the autosave file?")));
+				var (primaryMessageText, secondaryMessageText) = SplitMessageString (
+					BrandingService.BrandApplicationName (GettextCatalog.GetString (
+						"<b>An autosave file has been found for this file.</b>\n" +
+						"This could mean that another instance of MonoDevelop is editing this " +
+						"file, or that MonoDevelop crashed with unsaved changes.\n\n" +
+						"Do you want to use the original file, or load from the autosave file?")));
 
-// 				PresentInfobar (
-// 					primaryMessageText,
-// 					secondaryMessageText,
-// 					new InfoBarAction (
-// 						GetButtonString (GettextCatalog.GetString ("_Use original file")),
-// 						UseOriginalFile),
-// 					new InfoBarAction (
-// 						GetButtonString (GettextCatalog.GetString ("_Load from autosave")),
-// 						LoadFromAutosave,
-// 						isDefault: true));
+				PresentInfobar (
+					primaryMessageText,
+					secondaryMessageText,
+					new InfoBarAction (
+						GetButtonString (GettextCatalog.GetString ("_Use original file")),
+						UseOriginalFile),
+					new InfoBarAction (
+						GetButtonString (GettextCatalog.GetString ("_Load from autosave")),
+						LoadFromAutosave,
+						isDefault: true));
 
-// 				void OnActionSelected ()
-// 				{
-// 					DismissInfoBar ();
-// 					if (setWritable)
-// 						TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, false);
-// 				}
+				void OnActionSelected ()
+				{
+					DismissInfoBar ();
+					if (setWritable)
+						TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, false);
+				}
 
-// 				void LoadFromAutosave ()
-// 				{
-// 					try {
-// 						AutoSave.RemoveAutoSaveFile (FilePath);
-// 						ReplaceContent (autosaveContent.Text, autosaveContent.Encoding);
-// 					} catch (Exception e) {
-// 						LoggingService.LogError ("Could not load the autosave file", e);
-// 					} finally {
-// 						OnActionSelected ();
-// 					}
-// 				}
+				void LoadFromAutosave ()
+				{
+					try {
+						AutoSave.RemoveAutoSaveFile (FilePath);
+						ReplaceContent (autosaveContent.Text, autosaveContent.Encoding);
+					} catch (Exception e) {
+						LoggingService.LogError ("Could not load the autosave file", e);
+					} finally {
+						OnActionSelected ();
+					}
+				}
 
-// 				void UseOriginalFile ()
-// 				{
-// 					try {
-// 						AutoSave.RemoveAutoSaveFile (FilePath);
-// 					} catch (Exception e) {
-// 						LoggingService.LogError ("Could not remove the autosave file", e);
-// 					} finally {
-// 						OnActionSelected ();
-// 					}
-// 				}
-// 			}
+				void UseOriginalFile ()
+				{
+					try {
+						AutoSave.RemoveAutoSaveFile (FilePath);
+					} catch (Exception e) {
+						LoggingService.LogError ("Could not remove the autosave file", e);
+					} finally {
+						OnActionSelected ();
+					}
+				}
+			}
 
-// 			return Task.CompletedTask;
-// 		}
+			return Task.CompletedTask;
+		} */
 
 		/// <summary>
 		/// Replace document content with new content. This marks the document as dirty.

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -32,7 +32,7 @@ using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Utilities;
 
-using Microsoft.VisualStudio.CodingConventions;
+//using Microsoft.VisualStudio.CodingConventions;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 
@@ -49,7 +49,7 @@ using MonoDevelop.Projects.Policies;
 using MonoDevelop.Ide.Gui.Documents;
 
 using AutoSave = MonoDevelop.Ide.Editor.AutoSave;
-using EditorConfigService = MonoDevelop.Ide.Editor.EditorConfigService;
+//using EditorConfigService = MonoDevelop.Ide.Editor.EditorConfigService;
 using DefaultSourceEditorOptions = MonoDevelop.Ide.Editor.DefaultSourceEditorOptions;
 using MonoDevelop.Components;
 using System.Threading;
@@ -86,7 +86,7 @@ namespace MonoDevelop.TextEditor
 		static bool settingZoomLevel;
 
 		PolicyContainer policyContainer;
-		ICodingConventionContext editorConfigContext;
+		//ICodingConventionContext editorConfigContext;
 		bool warnOverwrite;
 		IDisposable textBufferRegistration;
 
@@ -161,7 +161,7 @@ namespace MonoDevelop.TextEditor
 			EditorOperations = (EditorOperationsInterface)Imports.EditorOperationsProvider.GetEditorOperations (TextView);
 			EditorOptions = Imports.EditorOptionsFactoryService.GetOptions (TextView);
 			TextBufferOptions = Imports.EditorOptionsFactoryService.GetOptions (TextView.TextBuffer);
-			UpdateTextEditorOptions (this, EventArgs.Empty);
+			//UpdateTextEditorOptions (this, EventArgs.Empty);
 			contentProviders = new List<IEditorContentProvider> (Imports.EditorContentProviderService.GetContentProvidersForView (TextView));
 
 			TextView.Properties [typeof (DocumentController)] = this;
@@ -199,7 +199,7 @@ namespace MonoDevelop.TextEditor
 			// Content providers can provide additional content
 			NotifyContentChanged ();
 
-			await Load (false);
+			////await Load (false);
 
 			return control;
 		}
@@ -249,11 +249,11 @@ namespace MonoDevelop.TextEditor
 
 			warnOverwrite = false;
 
-			if (editorConfigContext != null) {
-				editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
-				EditorConfigService.RemoveEditConfigContext (TextDocument.FilePath).Ignore ();
-				editorConfigContext = null;
-			}
+			// if (editorConfigContext != null) {
+			// 	editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
+			// 	EditorConfigService.RemoveEditConfigContext (TextDocument.FilePath).Ignore ();
+			// 	editorConfigContext = null;
+			// }
 
 			if (FilePath != TextDocument.FilePath && !string.IsNullOrEmpty (TextDocument.FilePath))
 				AutoSave.RemoveAutoSaveFile (TextDocument.FilePath);
@@ -272,7 +272,7 @@ namespace MonoDevelop.TextEditor
 
 			UpdateTextBufferRegistration ();
 
-			UpdateTextEditorOptions (null, null);
+			//UpdateTextEditorOptions (null, null);
 		}
 
 		protected override void OnOwnerChanged ()
@@ -280,7 +280,7 @@ namespace MonoDevelop.TextEditor
 			base.OnOwnerChanged ();
 
 			if (TextDocument != null) {
-				UpdateTextEditorOptions (null, null);
+				//UpdateTextEditorOptions (null, null);
 				UpdateTextBufferRegistration ();
 			}
 		}
@@ -312,19 +312,19 @@ namespace MonoDevelop.TextEditor
 
 			UnsubscribeFromEvents ();
 
-			if (policyContainer != null)
-				policyContainer.PolicyChanged -= PolicyChanged;
-			if (editorConfigContext != null) {
-				editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
-				EditorConfigService.RemoveEditConfigContext (FilePath).Ignore ();
-			}
+			//if (policyContainer != null)
+			//	policyContainer.PolicyChanged -= PolicyChanged;
+			//if (editorConfigContext != null) {
+				//editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
+				//EditorConfigService.RemoveEditConfigContext (FilePath).Ignore ();
+			//}
 
 			base.OnDispose ();
 		}
 
 		protected virtual void SubscribeToEvents ()
 		{
-			sourceEditorOptions.Changed += UpdateTextEditorOptions;
+			//sourceEditorOptions.Changed += UpdateTextEditorOptions;
 			TextDocument.DirtyStateChanged += HandleTextDocumentDirtyStateChanged;
 			TextBuffer.Changed += HandleTextBufferChanged;
 			TextView.Options.OptionChanged += TextBufferOptionsChanged;
@@ -332,8 +332,8 @@ namespace MonoDevelop.TextEditor
 
 		protected virtual void UnsubscribeFromEvents ()
 		{
-			if (sourceEditorOptions != null)
-				sourceEditorOptions.Changed -= UpdateTextEditorOptions;
+			// if (sourceEditorOptions != null)
+			// 	sourceEditorOptions.Changed -= UpdateTextEditorOptions;
 
 			if (TextDocument != null)
 				TextDocument.DirtyStateChanged -= HandleTextDocumentDirtyStateChanged;
@@ -362,38 +362,38 @@ namespace MonoDevelop.TextEditor
 				sourceEditorOptions.ShowLineNumberMargin);
 		}
 
-		void UpdateTextEditorOptions (object sender, EventArgs e)
-		{
-			UpdateTextEditorOptionsAsync ().Forget ();
-		}
+		// void UpdateTextEditorOptions (object sender, EventArgs e)
+		// {
+		// 	UpdateTextEditorOptionsAsync ().Forget ();
+		// }
 
-		async Task UpdateTextEditorOptionsAsync ()
-		{
-			UpdateLineNumberMarginOption ();
+		// async Task UpdateTextEditorOptionsAsync ()
+		// {
+		// 	UpdateLineNumberMarginOption ();
 
-			var foldMargin = PropertyService.Get<bool> ("ShowFoldMargin");
-			Imports.OutliningManagerService.GetOutliningManager (TextView).Enabled = foldMargin;
+		// 	var foldMargin = PropertyService.Get<bool> ("ShowFoldMargin");
+		// 	Imports.OutliningManagerService.GetOutliningManager (TextView).Enabled = foldMargin;
 
-			var newPolicyContainer = (Owner as IPolicyProvider)?.Policies;
-			if (newPolicyContainer != policyContainer) {
-				if (policyContainer != null)
-					policyContainer.PolicyChanged -= PolicyChanged;
-				policyContainer = newPolicyContainer;
-			}
-			if (policyContainer != null)
-				policyContainer.PolicyChanged += PolicyChanged;
+		// 	var newPolicyContainer = (Owner as IPolicyProvider)?.Policies;
+		// 	if (newPolicyContainer != policyContainer) {
+		// 		if (policyContainer != null)
+		// 			policyContainer.PolicyChanged -= PolicyChanged;
+		// 		policyContainer = newPolicyContainer;
+		// 	}
+		// 	if (policyContainer != null)
+		// 		policyContainer.PolicyChanged += PolicyChanged;
 
-			var newEditorConfigContext = await EditorConfigService.GetEditorConfigContext (FilePath, default);
-			if (newEditorConfigContext != editorConfigContext) {
-				if (editorConfigContext != null)
-					editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
-				editorConfigContext = newEditorConfigContext;
-			}
-			if (editorConfigContext != null)
-				editorConfigContext.CodingConventionsChangedAsync += UpdateOptionsFromEditorConfigAsync;
+		// 	var newEditorConfigContext = await EditorConfigService.GetEditorConfigContext (FilePath, default);
+		// 	if (newEditorConfigContext != editorConfigContext) {
+		// 		if (editorConfigContext != null)
+		// 			editorConfigContext.CodingConventionsChangedAsync -= UpdateOptionsFromEditorConfigAsync;
+		// 		editorConfigContext = newEditorConfigContext;
+		// 	}
+		// 	if (editorConfigContext != null)
+		// 		editorConfigContext.CodingConventionsChangedAsync += UpdateOptionsFromEditorConfigAsync;
 
-			await UpdateOptionsFromEditorConfigAsync (null, null);
-		}
+		// 	await UpdateOptionsFromEditorConfigAsync (null, null);
+		// }
 
 		void ClearOptionValue(string optionName)
 		{
@@ -438,179 +438,179 @@ namespace MonoDevelop.TextEditor
 #endif
 		}
 
-		private Task UpdateOptionsFromEditorConfigAsync (object sender, CodingConventionsChangedEventArgs args)
-		{
-			// Set base options first, then override with editorconfig values
-			UpdateOptionsFromPolicy ();
+// 		private Task UpdateOptionsFromEditorConfigAsync (object sender, CodingConventionsChangedEventArgs args)
+// 		{
+// 			// Set base options first, then override with editorconfig values
+// 			UpdateOptionsFromPolicy ();
 
-			if (editorConfigContext == null)
-				return Task.CompletedTask;
+// 			if (editorConfigContext == null)
+// 				return Task.CompletedTask;
 
-			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentStyle (out var indentStyle))
-				SetOptionValue (DefaultOptions.ConvertTabsToSpacesOptionName, indentStyle == IndentStyle.Spaces);
-			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetTabWidth (out var tabWidth))
-				SetOptionValue (DefaultOptions.TabSizeOptionName, tabWidth);
-			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentSize (out var indentSize))
-				SetOptionValue (DefaultOptions.IndentSizeOptionName, indentSize);
-			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetLineEnding (out var lineEnding))
-				SetOptionValue (DefaultOptions.NewLineCharacterOptionName, lineEnding);
-			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out var allowTrailingWhitespace))
-				SetOptionValue (DefaultOptions.TrimTrailingWhiteSpaceOptionName, !allowTrailingWhitespace);
+// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentStyle (out var indentStyle))
+// 				SetOptionValue (DefaultOptions.ConvertTabsToSpacesOptionName, indentStyle == IndentStyle.Spaces);
+// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetTabWidth (out var tabWidth))
+// 				SetOptionValue (DefaultOptions.TabSizeOptionName, tabWidth);
+// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetIndentSize (out var indentSize))
+// 				SetOptionValue (DefaultOptions.IndentSizeOptionName, indentSize);
+// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetLineEnding (out var lineEnding))
+// 				SetOptionValue (DefaultOptions.NewLineCharacterOptionName, lineEnding);
+// 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out var allowTrailingWhitespace))
+// 				SetOptionValue (DefaultOptions.TrimTrailingWhiteSpaceOptionName, !allowTrailingWhitespace);
 
-			var setVerticalRulers = false;
-			int [] verticalRulers = null;
+// 			var setVerticalRulers = false;
+// 			int [] verticalRulers = null;
 
-			// "Show column ruler" preference still needs to be checked, regardless of whether or not editorconfig
-			// has a setting for where rulers should appear
-			if (PropertyService.Get<bool> ("ShowRuler")) {
-				if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.RulersConvention, out var rulers)) {
-					setVerticalRulers = true;
-					if (!string.IsNullOrEmpty (rulers)) {
-						verticalRulers = Array.ConvertAll (rulers.Split (','), val => {
-							if (int.TryParse (val, out var col))
-								return col;
-							return 0;
-						});
-					}
-				} else if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out var maxLineLength)) {
-					if (maxLineLength != "off" && int.TryParse (maxLineLength, out var i)) {
-						setVerticalRulers = true;
-						verticalRulers = new [] { i };
-					} else
-						setVerticalRulers = false;
-				}
-			}
+// 			// "Show column ruler" preference still needs to be checked, regardless of whether or not editorconfig
+// 			// has a setting for where rulers should appear
+// 			if (PropertyService.Get<bool> ("ShowRuler")) {
+// 				if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.RulersConvention, out var rulers)) {
+// 					setVerticalRulers = true;
+// 					if (!string.IsNullOrEmpty (rulers)) {
+// 						verticalRulers = Array.ConvertAll (rulers.Split (','), val => {
+// 							if (int.TryParse (val, out var col))
+// 								return col;
+// 							return 0;
+// 						});
+// 					}
+// 				} else if (editorConfigContext.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out var maxLineLength)) {
+// 					if (maxLineLength != "off" && int.TryParse (maxLineLength, out var i)) {
+// 						setVerticalRulers = true;
+// 						verticalRulers = new [] { i };
+// 					} else
+// 						setVerticalRulers = false;
+// 				}
+// 			}
 
-#if !WINDOWS
-			if (setVerticalRulers)
-				EditorOptions.SetOptionValue (DefaultTextViewOptions.VerticalRulersName, verticalRulers ?? Array.Empty<int> ());
-#endif
+// #if !WINDOWS
+// 			if (setVerticalRulers)
+// 				EditorOptions.SetOptionValue (DefaultTextViewOptions.VerticalRulersName, verticalRulers ?? Array.Empty<int> ());
+// #endif
 
-			return Task.CompletedTask;
-		}
+// 			return Task.CompletedTask;
+// 		}
 
-		private void PolicyChanged (object sender, PolicyChangedEventArgs e)
-			=> UpdateTextEditorOptions (sender, e);
+// 		private void PolicyChanged (object sender, PolicyChangedEventArgs e)
+// 			=> UpdateTextEditorOptions (sender, e);
 
-		protected override object OnGetContent (Type type)
-		{
-			if (contentProviders != null) {
-				foreach (var provider in contentProviders) {
-					var content = provider.GetContent (TextView, type);
-					if (content != null) {
-						return content;
-					}
-				}
-			}
-			return GetIntrinsicType (type);
-		}
+// 		protected override object OnGetContent (Type type)
+// 		{
+// 			if (contentProviders != null) {
+// 				foreach (var provider in contentProviders) {
+// 					var content = provider.GetContent (TextView, type);
+// 					if (content != null) {
+// 						return content;
+// 					}
+// 				}
+// 			}
+// 			return GetIntrinsicType (type);
+// 		}
 
-		protected override IEnumerable<object> OnGetContents (Type type)
-		{
-			if (contentProviders != null) {
-				foreach (var provider in contentProviders) {
-					var contents = provider.GetContents (TextView, type);
-					if (contents != null) {
-						foreach (var content in contents)
-							yield return content;
-					}
-				}
-			}
+// 		protected override IEnumerable<object> OnGetContents (Type type)
+// 		{
+// 			if (contentProviders != null) {
+// 				foreach (var provider in contentProviders) {
+// 					var contents = provider.GetContents (TextView, type);
+// 					if (contents != null) {
+// 						foreach (var content in contents)
+// 							yield return content;
+// 					}
+// 				}
+// 			}
 
-			var intrinsicType = GetIntrinsicType (type);
-			if (intrinsicType != null) {
-				yield return intrinsicType;
-			}
-		}
+// 			var intrinsicType = GetIntrinsicType (type);
+// 			if (intrinsicType != null) {
+// 				yield return intrinsicType;
+// 			}
+// 		}
 
-		object GetIntrinsicType (Type type)
-		{
-			if (type.IsInstanceOfType (TextBuffer))
-				return TextBuffer;
-			if (type.IsInstanceOfType (TextDocument))
-				return TextDocument;
-			if (type.IsInstanceOfType (TextView))
-				return TextView;
-			if (type.IsInstanceOfType (this))
-				return this;
-			return null;
-		}
+// 		object GetIntrinsicType (Type type)
+// 		{
+// 			if (type.IsInstanceOfType (TextBuffer))
+// 				return TextBuffer;
+// 			if (type.IsInstanceOfType (TextDocument))
+// 				return TextDocument;
+// 			if (type.IsInstanceOfType (TextView))
+// 				return TextView;
+// 			if (type.IsInstanceOfType (this))
+// 				return this;
+// 			return null;
+// 		}
 
-		Task Load (bool reloading)
-		{
-			// We actually load initial content at construction time, so this
-			// overload only needs to cover reload and autosave scenarios
+// 		Task Load (bool reloading)
+// 		{
+// 			// We actually load initial content at construction time, so this
+// 			// overload only needs to cover reload and autosave scenarios
 
-			if (warnOverwrite) {
-				warnOverwrite = false;
-				DismissInfoBar ();
-				ShowNotification = false;
-			}
+// 			if (warnOverwrite) {
+// 				warnOverwrite = false;
+// 				DismissInfoBar ();
+// 				ShowNotification = false;
+// 			}
 
-			if (reloading) {
-				TextDocument.Reload ();
-			} else if (AutoSave.AutoSaveExists (FilePath)) {
-				var autosaveContent = AutoSave.LoadAutoSave (FilePath);
+// 			if (reloading) {
+// 				TextDocument.Reload ();
+// 			} else if (AutoSave.AutoSaveExists (FilePath)) {
+// 				var autosaveContent = AutoSave.LoadAutoSave (FilePath);
 
-				MarkDirty ();
-				warnOverwrite = true;
+// 				MarkDirty ();
+// 				warnOverwrite = true;
 
-				// Set editor read-only until user picks one of the above options.
-				var setWritable = !TextView.Options.DoesViewProhibitUserInput ();
-				if (setWritable)
-					TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, true);
+// 				// Set editor read-only until user picks one of the above options.
+// 				var setWritable = !TextView.Options.DoesViewProhibitUserInput ();
+// 				if (setWritable)
+// 					TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, true);
 
-				var (primaryMessageText, secondaryMessageText) = SplitMessageString (
-					BrandingService.BrandApplicationName (GettextCatalog.GetString (
-						"<b>An autosave file has been found for this file.</b>\n" +
-						"This could mean that another instance of MonoDevelop is editing this " +
-						"file, or that MonoDevelop crashed with unsaved changes.\n\n" +
-						"Do you want to use the original file, or load from the autosave file?")));
+// 				var (primaryMessageText, secondaryMessageText) = SplitMessageString (
+// 					BrandingService.BrandApplicationName (GettextCatalog.GetString (
+// 						"<b>An autosave file has been found for this file.</b>\n" +
+// 						"This could mean that another instance of MonoDevelop is editing this " +
+// 						"file, or that MonoDevelop crashed with unsaved changes.\n\n" +
+// 						"Do you want to use the original file, or load from the autosave file?")));
 
-				PresentInfobar (
-					primaryMessageText,
-					secondaryMessageText,
-					new InfoBarAction (
-						GetButtonString (GettextCatalog.GetString ("_Use original file")),
-						UseOriginalFile),
-					new InfoBarAction (
-						GetButtonString (GettextCatalog.GetString ("_Load from autosave")),
-						LoadFromAutosave,
-						isDefault: true));
+// 				PresentInfobar (
+// 					primaryMessageText,
+// 					secondaryMessageText,
+// 					new InfoBarAction (
+// 						GetButtonString (GettextCatalog.GetString ("_Use original file")),
+// 						UseOriginalFile),
+// 					new InfoBarAction (
+// 						GetButtonString (GettextCatalog.GetString ("_Load from autosave")),
+// 						LoadFromAutosave,
+// 						isDefault: true));
 
-				void OnActionSelected ()
-				{
-					DismissInfoBar ();
-					if (setWritable)
-						TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, false);
-				}
+// 				void OnActionSelected ()
+// 				{
+// 					DismissInfoBar ();
+// 					if (setWritable)
+// 						TextView.Options.SetOptionValue (DefaultTextViewOptions.ViewProhibitUserInputId, false);
+// 				}
 
-				void LoadFromAutosave ()
-				{
-					try {
-						AutoSave.RemoveAutoSaveFile (FilePath);
-						ReplaceContent (autosaveContent.Text, autosaveContent.Encoding);
-					} catch (Exception e) {
-						LoggingService.LogError ("Could not load the autosave file", e);
-					} finally {
-						OnActionSelected ();
-					}
-				}
+// 				void LoadFromAutosave ()
+// 				{
+// 					try {
+// 						AutoSave.RemoveAutoSaveFile (FilePath);
+// 						ReplaceContent (autosaveContent.Text, autosaveContent.Encoding);
+// 					} catch (Exception e) {
+// 						LoggingService.LogError ("Could not load the autosave file", e);
+// 					} finally {
+// 						OnActionSelected ();
+// 					}
+// 				}
 
-				void UseOriginalFile ()
-				{
-					try {
-						AutoSave.RemoveAutoSaveFile (FilePath);
-					} catch (Exception e) {
-						LoggingService.LogError ("Could not remove the autosave file", e);
-					} finally {
-						OnActionSelected ();
-					}
-				}
-			}
+// 				void UseOriginalFile ()
+// 				{
+// 					try {
+// 						AutoSave.RemoveAutoSaveFile (FilePath);
+// 					} catch (Exception e) {
+// 						LoggingService.LogError ("Could not remove the autosave file", e);
+// 					} finally {
+// 						OnActionSelected ();
+// 					}
+// 				}
+// 			}
 
-			return Task.CompletedTask;
-		}
+// 			return Task.CompletedTask;
+// 		}
 
 		/// <summary>
 		/// Replace document content with new content. This marks the document as dirty.
@@ -779,7 +779,7 @@ namespace MonoDevelop.TextEditor
 					if (IsDisposed || !File.Exists (FilePath))
 						return;
 
-					Load (true);
+					////Load (true);
 					ShowNotification = false;
 				} catch (Exception ex) {
 					MessageService.ShowError ("Could not reload the file.", ex);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -88,7 +88,7 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.1.2" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(NuGetVersionRoslyn)" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(NuGetVersionRoslyn)" PrivateAssets="runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" PrivateAssets="runtime" />
+    <!--<PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" PrivateAssets="runtime" />-->
 <!--    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(NuGetVersionVSComposition)" ExcludeAssets="all" />-->
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(NuGetVersionVSComposition)" PrivateAssets="runtime" />
     <!-- Need the net45 version, see https://github.com/mono/mono/issues/12461 -->
@@ -137,7 +137,7 @@
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.Workspaces.MSBuild.dll" />
     <IncludeCopyLocal Include="Microsoft.DiaSymReader.dll" />
     <IncludeCopyLocal Include="Microsoft.Extensions.ObjectPool.dll" />
-    <IncludeCopyLocal Include="Microsoft.VisualStudio.CodingConventions.dll" />
+    <!--<IncludeCopyLocal Include="Microsoft.VisualStudio.CodingConventions.dll" />-->
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Composition.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.CoreUtility.dll" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -127,7 +127,7 @@
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.ExternalAccess.MonoDevelop.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.Features.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.FlowAnalysis.Utilities.dll" />
-    <IncludeCopyLocal Include="Microsoft.CodeAnalysis.InteractiveHost.dll" />
+    <!--<IncludeCopyLocal Include="Microsoft.CodeAnalysis.InteractiveHost.dll" />-->
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.Scripting.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.VisualBasic.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll" />

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -1,6 +1,6 @@
 <ExtensionModel>
 	<Runtime>
-		<Import assembly="Microsoft.VisualStudio.CodingConventions.dll" />
+		<!--<Import assembly="Microsoft.VisualStudio.CodingConventions.dll" />-->
 		<Import assembly="Microsoft.VisualStudio.Composition.dll" />
 		<Import assembly="Microsoft.VisualStudio.CoreUtility.dll" />
 		<Import assembly="Microsoft.VisualStudio.Language.dll" />
@@ -431,7 +431,7 @@
 		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" />
 		<Assembly file="Microsoft.CodeAnalysis.Workspaces.dll" />
 		<Assembly file="Microsoft.CodeAnalysis.Workspaces.MSBuild.dll" />
-		<Assembly file="Microsoft.VisualStudio.CodingConventions.dll" />
+		<!--<Assembly file="Microsoft.VisualStudio.CodingConventions.dll" />-->
 		<Assembly file="Microsoft.VisualStudio.Language.dll" />
 		<Assembly file="Microsoft.VisualStudio.Language.StandardClassification.dll"/>
 		<Assembly file="Microsoft.VisualStudio.Text.Logic.dll"/>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
@@ -280,10 +280,10 @@ namespace MonoDevelop.Ide.Editor
 			//IdeApp.Preferences.Editor.FollowCodingConventions.Changed += OnFollowCodingConventionsChanged;
 		}
 
-		// void OnFollowCodingConventionsChanged (object sender, EventArgs e)
-		// {
-		// 	UpdateContextOptions (null, null).Ignore ();
-		// }
+		/* void OnFollowCodingConventionsChanged (object sender, EventArgs e)
+		{
+			UpdateContextOptions (null, null).Ignore ();
+		} */
 
 
 		void UpdateFont ()
@@ -319,57 +319,57 @@ namespace MonoDevelop.Ide.Editor
 			return result;
 		}
 
-		// internal void SetContext (ICodingConventionContext context)
-		// {
-		// 	if (this.context == context)
-		// 		return;
-		// 	if (this.context != null)
-		// 		this.context.CodingConventionsChangedAsync -= UpdateContextOptions;
-		// 	this.context = context;
-		// 	context.CodingConventionsChangedAsync += UpdateContextOptions;
-		// 	UpdateContextOptions (null, null).Ignore ();
-		// }
+		/* internal void SetContext (ICodingConventionContext context)
+		{
+			if (this.context == context)
+				return;
+			if (this.context != null)
+				this.context.CodingConventionsChangedAsync -= UpdateContextOptions;
+			this.context = context;
+			context.CodingConventionsChangedAsync += UpdateContextOptions;
+			UpdateContextOptions (null, null).Ignore ();
+		}
 
-		// private Task UpdateContextOptions (object sender, CodingConventionsChangedEventArgs arg)
-		// {
-		// 	if (context == null)
-		// 		return Task.CompletedTask;
+		private Task UpdateContextOptions (object sender, CodingConventionsChangedEventArgs arg)
+		{
+			if (context == null)
+				return Task.CompletedTask;
 
-		// 	bool followCodingConventions = IdeApp.Preferences.Editor.FollowCodingConventions;
+			bool followCodingConventions = IdeApp.Preferences.Editor.FollowCodingConventions;
 
-		// 	defaultEolMarkerFromContext = null;
-		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetLineEnding (out string eolMarker))
-		// 		defaultEolMarkerFromContext = eolMarker;
+			defaultEolMarkerFromContext = null;
+			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetLineEnding (out string eolMarker))
+				defaultEolMarkerFromContext = eolMarker;
 
-		// 	tabsToSpacesFromContext = null;
-		// 	//if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
-		// 	//	tabsToSpacesFromContext = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
+			tabsToSpacesFromContext = null;
+			//if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
+			//	tabsToSpacesFromContext = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
 
-		// 	indentationSizeFromContext = null;
-		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentSize (out int indentSize)) 
-		// 		indentationSizeFromContext = indentSize;
+			indentationSizeFromContext = null;
+			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentSize (out int indentSize)) 
+				indentationSizeFromContext = indentSize;
 
-		// 	removeTrailingWhitespacesFromContext = null;
-		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out bool allowTrailing))
-		// 		removeTrailingWhitespacesFromContext = !allowTrailing;
+			removeTrailingWhitespacesFromContext = null;
+			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out bool allowTrailing))
+				removeTrailingWhitespacesFromContext = !allowTrailing;
 
-		// 	tabSizeFromContext = null;
-		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetTabWidth (out int tSize))
-		// 		tabSizeFromContext = tSize;
+			tabSizeFromContext = null;
+			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetTabWidth (out int tSize))
+				tabSizeFromContext = tSize;
 
-		// 	rulerColumnFromContext = null;
-		// 	showRulerFromContext = null;
-		// 	if (followCodingConventions && context.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out string maxLineLength)) {
-		// 		if (maxLineLength != "off" && int.TryParse (maxLineLength, out int i)) {
-		// 			rulerColumnFromContext = i;
-		// 			showRulerFromContext = true;
-		// 		} else {
-		// 			showRulerFromContext = false;
-		// 		}
-		// 	}
-		// 	this.FireChange ();
-		// 	return Task.CompletedTask;
-		// }
+			rulerColumnFromContext = null;
+			showRulerFromContext = null;
+			if (followCodingConventions && context.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out string maxLineLength)) {
+				if (maxLineLength != "off" && int.TryParse (maxLineLength, out int i)) {
+					rulerColumnFromContext = i;
+					showRulerFromContext = true;
+				} else {
+					showRulerFromContext = false;
+				}
+			}
+			this.FireChange ();
+			return Task.CompletedTask;
+		} */
 
 		#region new options
 
@@ -929,15 +929,15 @@ namespace MonoDevelop.Ide.Editor
 		}
 		#endregion
 		
-		 public void Dispose ()
-		 {
-		// 	IdeServices.FontService.RemoveCallback (UpdateFont);
-		// 	IdeApp.Preferences.ColorScheme.Changed -= OnColorSchemeChanged;
-		// 	IdeApp.Preferences.Editor.FollowCodingConventions.Changed -= OnFollowCodingConventionsChanged;
-		// 	if (context != null)
-		// 		context.CodingConventionsChangedAsync -= UpdateContextOptions;
+		public void Dispose ()
+		{
+			/* IdeServices.FontService.RemoveCallback (UpdateFont);
+			IdeApp.Preferences.ColorScheme.Changed -= OnColorSchemeChanged;
+			IdeApp.Preferences.Editor.FollowCodingConventions.Changed -= OnFollowCodingConventionsChanged;
+			if (context != null)
+				context.CodingConventionsChangedAsync -= UpdateContextOptions; */
 		
-		 }
+		} 
 
 		void OnChanged (EventArgs args)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
@@ -28,7 +28,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Ide.Fonts;
 using MonoDevelop.Ide.Editor.Extension;
-using Microsoft.VisualStudio.CodingConventions;
+//using Microsoft.VisualStudio.CodingConventions;
 using System.Threading.Tasks;
 using MonoDevelop.Ide.TypeSystem;
 
@@ -58,7 +58,7 @@ namespace MonoDevelop.Ide.Editor
 		static DefaultSourceEditorOptions instance;
 		static ITextEditorOptions plainEditor;
 		static bool inited;
-		ICodingConventionContext context;
+		//ICodingConventionContext context;
 
 		public static DefaultSourceEditorOptions Instance {
 			get {
@@ -277,13 +277,13 @@ namespace MonoDevelop.Ide.Editor
 			});
 
 			IdeApp.Preferences.ColorScheme.Changed += OnColorSchemeChanged;
-			IdeApp.Preferences.Editor.FollowCodingConventions.Changed += OnFollowCodingConventionsChanged;
+			//IdeApp.Preferences.Editor.FollowCodingConventions.Changed += OnFollowCodingConventionsChanged;
 		}
 
-		void OnFollowCodingConventionsChanged (object sender, EventArgs e)
-		{
-			UpdateContextOptions (null, null).Ignore ();
-		}
+		// void OnFollowCodingConventionsChanged (object sender, EventArgs e)
+		// {
+		// 	UpdateContextOptions (null, null).Ignore ();
+		// }
 
 
 		void UpdateFont ()
@@ -319,57 +319,57 @@ namespace MonoDevelop.Ide.Editor
 			return result;
 		}
 
-		internal void SetContext (ICodingConventionContext context)
-		{
-			if (this.context == context)
-				return;
-			if (this.context != null)
-				this.context.CodingConventionsChangedAsync -= UpdateContextOptions;
-			this.context = context;
-			context.CodingConventionsChangedAsync += UpdateContextOptions;
-			UpdateContextOptions (null, null).Ignore ();
-		}
+		// internal void SetContext (ICodingConventionContext context)
+		// {
+		// 	if (this.context == context)
+		// 		return;
+		// 	if (this.context != null)
+		// 		this.context.CodingConventionsChangedAsync -= UpdateContextOptions;
+		// 	this.context = context;
+		// 	context.CodingConventionsChangedAsync += UpdateContextOptions;
+		// 	UpdateContextOptions (null, null).Ignore ();
+		// }
 
-		private Task UpdateContextOptions (object sender, CodingConventionsChangedEventArgs arg)
-		{
-			if (context == null)
-				return Task.CompletedTask;
+		// private Task UpdateContextOptions (object sender, CodingConventionsChangedEventArgs arg)
+		// {
+		// 	if (context == null)
+		// 		return Task.CompletedTask;
 
-			bool followCodingConventions = IdeApp.Preferences.Editor.FollowCodingConventions;
+		// 	bool followCodingConventions = IdeApp.Preferences.Editor.FollowCodingConventions;
 
-			defaultEolMarkerFromContext = null;
-			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetLineEnding (out string eolMarker))
-				defaultEolMarkerFromContext = eolMarker;
+		// 	defaultEolMarkerFromContext = null;
+		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetLineEnding (out string eolMarker))
+		// 		defaultEolMarkerFromContext = eolMarker;
 
-			tabsToSpacesFromContext = null;
-			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
-				tabsToSpacesFromContext = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
+		// 	tabsToSpacesFromContext = null;
+		// 	//if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
+		// 	//	tabsToSpacesFromContext = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
 
-			indentationSizeFromContext = null;
-			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentSize (out int indentSize)) 
-				indentationSizeFromContext = indentSize;
+		// 	indentationSizeFromContext = null;
+		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetIndentSize (out int indentSize)) 
+		// 		indentationSizeFromContext = indentSize;
 
-			removeTrailingWhitespacesFromContext = null;
-			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out bool allowTrailing))
-				removeTrailingWhitespacesFromContext = !allowTrailing;
+		// 	removeTrailingWhitespacesFromContext = null;
+		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out bool allowTrailing))
+		// 		removeTrailingWhitespacesFromContext = !allowTrailing;
 
-			tabSizeFromContext = null;
-			if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetTabWidth (out int tSize))
-				tabSizeFromContext = tSize;
+		// 	tabSizeFromContext = null;
+		// 	if (followCodingConventions && context.CurrentConventions.UniversalConventions.TryGetTabWidth (out int tSize))
+		// 		tabSizeFromContext = tSize;
 
-			rulerColumnFromContext = null;
-			showRulerFromContext = null;
-			if (followCodingConventions && context.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out string maxLineLength)) {
-				if (maxLineLength != "off" && int.TryParse (maxLineLength, out int i)) {
-					rulerColumnFromContext = i;
-					showRulerFromContext = true;
-				} else {
-					showRulerFromContext = false;
-				}
-			}
-			this.FireChange ();
-			return Task.CompletedTask;
-		}
+		// 	rulerColumnFromContext = null;
+		// 	showRulerFromContext = null;
+		// 	if (followCodingConventions && context.CurrentConventions.TryGetConventionValue<string> (EditorConfigService.MaxLineLengthConvention, out string maxLineLength)) {
+		// 		if (maxLineLength != "off" && int.TryParse (maxLineLength, out int i)) {
+		// 			rulerColumnFromContext = i;
+		// 			showRulerFromContext = true;
+		// 		} else {
+		// 			showRulerFromContext = false;
+		// 		}
+		// 	}
+		// 	this.FireChange ();
+		// 	return Task.CompletedTask;
+		// }
 
 		#region new options
 
@@ -929,14 +929,15 @@ namespace MonoDevelop.Ide.Editor
 		}
 		#endregion
 		
-		public void Dispose ()
-		{
-			IdeServices.FontService.RemoveCallback (UpdateFont);
-			IdeApp.Preferences.ColorScheme.Changed -= OnColorSchemeChanged;
-			IdeApp.Preferences.Editor.FollowCodingConventions.Changed -= OnFollowCodingConventionsChanged;
-			if (context != null)
-				context.CodingConventionsChangedAsync -= UpdateContextOptions;
-		}
+		 public void Dispose ()
+		 {
+		// 	IdeServices.FontService.RemoveCallback (UpdateFont);
+		// 	IdeApp.Preferences.ColorScheme.Changed -= OnColorSchemeChanged;
+		// 	IdeApp.Preferences.Editor.FollowCodingConventions.Changed -= OnFollowCodingConventionsChanged;
+		// 	if (context != null)
+		// 		context.CodingConventionsChangedAsync -= UpdateContextOptions;
+		
+		 }
 
 		void OnChanged (EventArgs args)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
@@ -23,177 +23,177 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-//using System;
-//using System.Collections.Immutable;
-//using System.IO;
-//using System.Linq;
-//using System.Threading;
-//using System.Threading.Tasks;
-//using Microsoft.VisualStudio.CodingConventions;
-//using System.Collections.Generic;
-//using MonoDevelop.Core;
-//using MonoDevelop.Projects;
+/* using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.CodingConventions;
+using System.Collections.Generic;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
 
-//namespace MonoDevelop.Ide.Editor
-//{
-	//static class EditorConfigService
-	//{
-		//public readonly static string MaxLineLengthConvention = "max_line_length";
-		//public readonly static string RulersConvention = "rulers";
+namespace MonoDevelop.Ide.Editor
+{
+	static class EditorConfigService
+	{
+		public readonly static string MaxLineLengthConvention = "max_line_length";
+		public readonly static string RulersConvention = "rulers";
 
-		//readonly static object contextCacheLock = new object ();
-		//readonly static ICodingConventionsManager codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager (new ConventionsFileManager());
-		//static ImmutableDictionary<string, ICodingConventionContext> contextCache = ImmutableDictionary<string, ICodingConventionContext>.Empty;
-		//public static class GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
-		// public static async Task<ICodingConventionContext> GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
-		// {
-		// 	if (string.IsNullOrEmpty (fileName))
-		// 		return null;
-		// 	try {
-		// 		var directory = Path.GetDirectoryName (fileName);
-		// 		if (string.IsNullOrEmpty (directory)) {
-		// 			return null;
-		// 		}
+		readonly static object contextCacheLock = new object ();
+		readonly static ICodingConventionsManager codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager (new ConventionsFileManager());
+		static ImmutableDictionary<string, ICodingConventionContext> contextCache = ImmutableDictionary<string, ICodingConventionContext>.Empty;
+		public static class GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
+		public static async Task<ICodingConventionContext> GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
+		{
+			if (string.IsNullOrEmpty (fileName))
+				return null;
+			try {
+				var directory = Path.GetDirectoryName (fileName);
+				if (string.IsNullOrEmpty (directory)) {
+					return null;
+				}
 
-		// 		// HACK: Work around for a library issue https://github.com/mono/monodevelop/issues/6104
-		// 		if (directory == "/") {
-		// 			return null;
-		// 		}
-		// 	} catch {
-		// 		return null;
-		// 	}
-		// 	if (contextCache.TryGetValue (fileName, out var oldresult))
-		// 		return oldresult;
-		// 	try {
-		// 		var result = await codingConventionsManager.GetConventionContextAsync (fileName, token);
-		// 		lock (contextCacheLock) {
-		// 			// check if another thread already requested a coding convention context and ensure
-		// 			// that only one is alive.
-		// 			if (contextCache.TryGetValue (fileName, out var result2)) {
-		// 				if (result != result2)
-		// 					result.Dispose ();
-		// 				return result2;
-		// 			}
-		// 			contextCache = contextCache.SetItem (fileName, result);
-		// 		}
-		// 		return result;
-		// 	} catch (OperationCanceledException) {
-		// 		return null;
-		// 	} catch (Exception e) {
-		// 		LoggingService.LogError ("Error while getting coding conventions,", e);
-		// 		return null;
-		// 	}
-		// }
+				// HACK: Work around for a library issue https://github.com/mono/monodevelop/issues/6104
+				if (directory == "/") {
+					return null;
+				}
+			} catch {
+				return null;
+			}
+			if (contextCache.TryGetValue (fileName, out var oldresult))
+				return oldresult;
+			try {
+				var result = await codingConventionsManager.GetConventionContextAsync (fileName, token);
+				lock (contextCacheLock) {
+					// check if another thread already requested a coding convention context and ensure
+					// that only one is alive.
+					if (contextCache.TryGetValue (fileName, out var result2)) {
+						if (result != result2)
+							result.Dispose ();
+						return result2;
+					}
+					contextCache = contextCache.SetItem (fileName, result);
+				}
+				return result;
+			} catch (OperationCanceledException) {
+				return null;
+			} catch (Exception e) {
+				LoggingService.LogError ("Error while getting coding conventions,", e);
+				return null;
+			}
+		}
 
-		// public static Task RemoveEditConfigContext (string fileName)
-		// {
-		// 	return Task.Run (() => {
-		// 		ICodingConventionContext ctx;
-		// 		lock (contextCacheLock) {
-		// 			if (!contextCache.TryGetValue (fileName, out ctx))
-		// 				return;
-		// 			contextCache = contextCache.Remove (fileName);
-		// 		}
-		// 		if (ctx != null)
-		// 			ctx.Dispose ();
-		// 	});
-		// }
+		public static Task RemoveEditConfigContext (string fileName)
+		{
+			return Task.Run (() => {
+				ICodingConventionContext ctx;
+				lock (contextCacheLock) {
+					if (!contextCache.TryGetValue (fileName, out ctx))
+						return;
+					contextCache = contextCache.Remove (fileName);
+				}
+				if (ctx != null)
+					ctx.Dispose ();
+			});
+		}
 
-	// 	 class ConventionsFileManager : IFileWatcher
-	// 	 {
-	// 	 	HashSet<FilePath> watchedFiles = new HashSet<FilePath> ();
+		 class ConventionsFileManager : IFileWatcher
+		 {
+		 	HashSet<FilePath> watchedFiles = new HashSet<FilePath> ();
 
-	// 		public event ConventionsFileChangedAsyncEventHandler ConventionFileChanged;
-	// 	 	public event ContextFileMovedAsyncEventHandler ContextFileMoved;
+			public event ConventionsFileChangedAsyncEventHandler ConventionFileChanged;
+		 	public event ContextFileMovedAsyncEventHandler ContextFileMoved;
 
-	// 	 	public ConventionsFileManager ()
-	// 	 	{
-	// 	 		FileService.FileChanged += FileService_FileChanged;
-	// 	 		FileService.FileRemoved += FileService_FileRemoved;
-	// 	 		FileService.FileMoved += FileService_FileMoved;
-	// 	 		FileService.FileRenamed += FileService_FileMoved;
-	// 	 	}
+		 	public ConventionsFileManager ()
+		 	{
+		 		FileService.FileChanged += FileService_FileChanged;
+		 		FileService.FileRemoved += FileService_FileRemoved;
+		 		FileService.FileMoved += FileService_FileMoved;
+		 		FileService.FileRenamed += FileService_FileMoved;
+		 	}
 
-	// 	 	void FileService_FileMoved (object sender, FileCopyEventArgs e)
-	// 	 	{
-	// 	 		lock (watchedFiles) {
-	// 	 			foreach (var file in e) {
-	// 	 				if (watchedFiles.Remove (file.SourceFile)) {
-	// 	 					ContextFileMoved?.Invoke (this, new ContextFileMovedEventArgs (file.SourceFile, file.TargetFile));
-	// 	 					if (file.SourceFile == file.TargetFile) {
-	// 	 						StartWatching (file.TargetFile.FileName, file.TargetFile.ParentDirectory);
-	// 	 					}
-	// 	 				}
-	// 	 			}
-	// 	 		}
-	// 	 	}
+		 	void FileService_FileMoved (object sender, FileCopyEventArgs e)
+		 	{
+		 		lock (watchedFiles) {
+		 			foreach (var file in e) {
+		 				if (watchedFiles.Remove (file.SourceFile)) {
+		 					ContextFileMoved?.Invoke (this, new ContextFileMovedEventArgs (file.SourceFile, file.TargetFile));
+		 					if (file.SourceFile == file.TargetFile) {
+		 						StartWatching (file.TargetFile.FileName, file.TargetFile.ParentDirectory);
+		 					}
+		 				}
+		 			}
+		 		}
+		 	}
 
-	// 		 void FileService_FileChanged (object sender, FileEventArgs e)
-	// 		 {
-	// 		 	lock (watchedFiles) {
-	// 		 		foreach (var file in e) {
-	// 		 			if (watchedFiles.Contains (file.FileName)) {
-	// 		 				ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileModified));
-	// 		 			}
-	// 		 		}
-	// 		 	}
-	// 		 }
+			 void FileService_FileChanged (object sender, FileEventArgs e)
+			 {
+			 	lock (watchedFiles) {
+			 		foreach (var file in e) {
+			 			if (watchedFiles.Contains (file.FileName)) {
+			 				ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileModified));
+			 			}
+			 		}
+			 	}
+			 }
 
-	// 		 void FileService_FileRemoved (object sender, FileEventArgs e)
-	// 		 {
-	// 		 	lock (watchedFiles) {
-	// 		 		foreach (var file in e) {
-	// 		 			if (watchedFiles.Remove (file.FileName)) {
-	// 		 				ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileDeleted));
-	// 		 				WatchDirectories ();
-	// 		 			}
-	// 		 		}
-	// 		 	}
-	// 		 }
+			 void FileService_FileRemoved (object sender, FileEventArgs e)
+			 {
+			 	lock (watchedFiles) {
+			 		foreach (var file in e) {
+			 			if (watchedFiles.Remove (file.FileName)) {
+			 				ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileDeleted));
+			 				WatchDirectories ();
+			 			}
+			 		}
+			 	}
+			 }
 
-	// 	 	public void Dispose ()
-	// 	 	{
-	// 	 		FileService.FileMoved -= FileService_FileMoved;
-	// 	 		FileService.FileRenamed -= FileService_FileMoved;
-	// 	 		FileService.FileRemoved -= FileService_FileRemoved;
-	// 	 		FileService.FileChanged -= FileService_FileChanged;
-	// 	 		FileWatcherService.WatchDirectories (this, null).Ignore ();
-	// 	 		lock (watchedFiles) {
-	// 	 			watchedFiles = null;
-	// 	 		}
-	// 	 	}
+		 	public void Dispose ()
+		 	{
+		 		FileService.FileMoved -= FileService_FileMoved;
+		 		FileService.FileRenamed -= FileService_FileMoved;
+		 		FileService.FileRemoved -= FileService_FileRemoved;
+		 		FileService.FileChanged -= FileService_FileChanged;
+		 		FileWatcherService.WatchDirectories (this, null).Ignore ();
+		 		lock (watchedFiles) {
+		 			watchedFiles = null;
+		 		}
+		 	}
 
-	// 	 	public void StartWatching (string fileName, string directoryPath)
-	// 	 	{
-	// 	 		lock (watchedFiles) {
-	// 	 			var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
+		 	public void StartWatching (string fileName, string directoryPath)
+		 	{
+		 		lock (watchedFiles) {
+		 			var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
 
-	// 	 			if (!File.Exists (key))
-	// 	 				return;
+		 			if (!File.Exists (key))
+		 				return;
 
-	// 	 			if (!watchedFiles.Add (key))
-	// 	 				return;
+		 			if (!watchedFiles.Add (key))
+		 				return;
 
-	// 	 			WatchDirectories ();
-	// 	 		}
-	// 	 	}
+		 			WatchDirectories ();
+		 		}
+		 	}
 
-	// 	 	public void StopWatching (string fileName, string directoryPath)
-	// 	 	{
-	// 	 		lock (watchedFiles) {
+		 	public void StopWatching (string fileName, string directoryPath)
+		 	{
+		 		lock (watchedFiles) {
 		
-	// 	 			var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
-	// 	 			if (watchedFiles.Remove (key)) {
-	// 	 				WatchDirectories ();
-	// 	 			}
-	// 	 		}
-	// 	 	}
+		 			var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
+		 			if (watchedFiles.Remove (key)) {
+		 				WatchDirectories ();
+		 			}
+		 		}
+		 	}
 
-	// 	 	void WatchDirectories ()
-	// 	 	{
-	// 	 		var directories = watchedFiles.Count == 0 ? null : watchedFiles.Select (file => new FilePath (file).ParentDirectory);
-	// 	 		FileWatcherService.WatchDirectories (this, directories).Ignore ();
-	// 	 	}
-	 //	 }
-	// }
-//}
+		 	void WatchDirectories ()
+		 	{
+		 		var directories = watchedFiles.Count == 0 ? null : watchedFiles.Select (file => new FilePath (file).ParentDirectory);
+		 		FileWatcherService.WatchDirectories (this, directories).Ignore ();
+		 	}
+	 	 }
+	}
+} */

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
@@ -23,176 +23,177 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.CodingConventions;
-using System.Collections.Generic;
-using MonoDevelop.Core;
-using MonoDevelop.Projects;
+//using System;
+//using System.Collections.Immutable;
+//using System.IO;
+//using System.Linq;
+//using System.Threading;
+//using System.Threading.Tasks;
+//using Microsoft.VisualStudio.CodingConventions;
+//using System.Collections.Generic;
+//using MonoDevelop.Core;
+//using MonoDevelop.Projects;
 
-namespace MonoDevelop.Ide.Editor
-{
-	static class EditorConfigService
-	{
-		public readonly static string MaxLineLengthConvention = "max_line_length";
-		public readonly static string RulersConvention = "rulers";
+//namespace MonoDevelop.Ide.Editor
+//{
+	//static class EditorConfigService
+	//{
+		//public readonly static string MaxLineLengthConvention = "max_line_length";
+		//public readonly static string RulersConvention = "rulers";
 
-		readonly static object contextCacheLock = new object ();
-		readonly static ICodingConventionsManager codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager (new ConventionsFileManager());
-		static ImmutableDictionary<string, ICodingConventionContext> contextCache = ImmutableDictionary<string, ICodingConventionContext>.Empty;
+		//readonly static object contextCacheLock = new object ();
+		//readonly static ICodingConventionsManager codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager (new ConventionsFileManager());
+		//static ImmutableDictionary<string, ICodingConventionContext> contextCache = ImmutableDictionary<string, ICodingConventionContext>.Empty;
+		//public static class GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
+		// public static async Task<ICodingConventionContext> GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
+		// {
+		// 	if (string.IsNullOrEmpty (fileName))
+		// 		return null;
+		// 	try {
+		// 		var directory = Path.GetDirectoryName (fileName);
+		// 		if (string.IsNullOrEmpty (directory)) {
+		// 			return null;
+		// 		}
 
-		public static async Task<ICodingConventionContext> GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
-		{
-			if (string.IsNullOrEmpty (fileName))
-				return null;
-			try {
-				var directory = Path.GetDirectoryName (fileName);
-				if (string.IsNullOrEmpty (directory)) {
-					return null;
-				}
+		// 		// HACK: Work around for a library issue https://github.com/mono/monodevelop/issues/6104
+		// 		if (directory == "/") {
+		// 			return null;
+		// 		}
+		// 	} catch {
+		// 		return null;
+		// 	}
+		// 	if (contextCache.TryGetValue (fileName, out var oldresult))
+		// 		return oldresult;
+		// 	try {
+		// 		var result = await codingConventionsManager.GetConventionContextAsync (fileName, token);
+		// 		lock (contextCacheLock) {
+		// 			// check if another thread already requested a coding convention context and ensure
+		// 			// that only one is alive.
+		// 			if (contextCache.TryGetValue (fileName, out var result2)) {
+		// 				if (result != result2)
+		// 					result.Dispose ();
+		// 				return result2;
+		// 			}
+		// 			contextCache = contextCache.SetItem (fileName, result);
+		// 		}
+		// 		return result;
+		// 	} catch (OperationCanceledException) {
+		// 		return null;
+		// 	} catch (Exception e) {
+		// 		LoggingService.LogError ("Error while getting coding conventions,", e);
+		// 		return null;
+		// 	}
+		// }
 
-				// HACK: Work around for a library issue https://github.com/mono/monodevelop/issues/6104
-				if (directory == "/") {
-					return null;
-				}
-			} catch {
-				return null;
-			}
-			if (contextCache.TryGetValue (fileName, out var oldresult))
-				return oldresult;
-			try {
-				var result = await codingConventionsManager.GetConventionContextAsync (fileName, token);
-				lock (contextCacheLock) {
-					// check if another thread already requested a coding convention context and ensure
-					// that only one is alive.
-					if (contextCache.TryGetValue (fileName, out var result2)) {
-						if (result != result2)
-							result.Dispose ();
-						return result2;
-					}
-					contextCache = contextCache.SetItem (fileName, result);
-				}
-				return result;
-			} catch (OperationCanceledException) {
-				return null;
-			} catch (Exception e) {
-				LoggingService.LogError ("Error while getting coding conventions,", e);
-				return null;
-			}
-		}
+		// public static Task RemoveEditConfigContext (string fileName)
+		// {
+		// 	return Task.Run (() => {
+		// 		ICodingConventionContext ctx;
+		// 		lock (contextCacheLock) {
+		// 			if (!contextCache.TryGetValue (fileName, out ctx))
+		// 				return;
+		// 			contextCache = contextCache.Remove (fileName);
+		// 		}
+		// 		if (ctx != null)
+		// 			ctx.Dispose ();
+		// 	});
+		// }
 
-		public static Task RemoveEditConfigContext (string fileName)
-		{
-			return Task.Run (() => {
-				ICodingConventionContext ctx;
-				lock (contextCacheLock) {
-					if (!contextCache.TryGetValue (fileName, out ctx))
-						return;
-					contextCache = contextCache.Remove (fileName);
-				}
-				if (ctx != null)
-					ctx.Dispose ();
-			});
-		}
+	// 	 class ConventionsFileManager : IFileWatcher
+	// 	 {
+	// 	 	HashSet<FilePath> watchedFiles = new HashSet<FilePath> ();
 
-		class ConventionsFileManager : IFileWatcher
-		{
-			HashSet<FilePath> watchedFiles = new HashSet<FilePath> ();
+	// 		public event ConventionsFileChangedAsyncEventHandler ConventionFileChanged;
+	// 	 	public event ContextFileMovedAsyncEventHandler ContextFileMoved;
 
-			public event ConventionsFileChangedAsyncEventHandler ConventionFileChanged;
-			public event ContextFileMovedAsyncEventHandler ContextFileMoved;
+	// 	 	public ConventionsFileManager ()
+	// 	 	{
+	// 	 		FileService.FileChanged += FileService_FileChanged;
+	// 	 		FileService.FileRemoved += FileService_FileRemoved;
+	// 	 		FileService.FileMoved += FileService_FileMoved;
+	// 	 		FileService.FileRenamed += FileService_FileMoved;
+	// 	 	}
 
-			public ConventionsFileManager ()
-			{
-				FileService.FileChanged += FileService_FileChanged;
-				FileService.FileRemoved += FileService_FileRemoved;
-				FileService.FileMoved += FileService_FileMoved;
-				FileService.FileRenamed += FileService_FileMoved;
-			}
+	// 	 	void FileService_FileMoved (object sender, FileCopyEventArgs e)
+	// 	 	{
+	// 	 		lock (watchedFiles) {
+	// 	 			foreach (var file in e) {
+	// 	 				if (watchedFiles.Remove (file.SourceFile)) {
+	// 	 					ContextFileMoved?.Invoke (this, new ContextFileMovedEventArgs (file.SourceFile, file.TargetFile));
+	// 	 					if (file.SourceFile == file.TargetFile) {
+	// 	 						StartWatching (file.TargetFile.FileName, file.TargetFile.ParentDirectory);
+	// 	 					}
+	// 	 				}
+	// 	 			}
+	// 	 		}
+	// 	 	}
 
-			void FileService_FileMoved (object sender, FileCopyEventArgs e)
-			{
-				lock (watchedFiles) {
-					foreach (var file in e) {
-						if (watchedFiles.Remove (file.SourceFile)) {
-							ContextFileMoved?.Invoke (this, new ContextFileMovedEventArgs (file.SourceFile, file.TargetFile));
-							if (file.SourceFile == file.TargetFile) {
-								StartWatching (file.TargetFile.FileName, file.TargetFile.ParentDirectory);
-							}
-						}
-					}
-				}
-			}
+	// 		 void FileService_FileChanged (object sender, FileEventArgs e)
+	// 		 {
+	// 		 	lock (watchedFiles) {
+	// 		 		foreach (var file in e) {
+	// 		 			if (watchedFiles.Contains (file.FileName)) {
+	// 		 				ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileModified));
+	// 		 			}
+	// 		 		}
+	// 		 	}
+	// 		 }
 
-			void FileService_FileChanged (object sender, FileEventArgs e)
-			{
-				lock (watchedFiles) {
-					foreach (var file in e) {
-						if (watchedFiles.Contains (file.FileName)) {
-							ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileModified));
-						}
-					}
-				}
-			}
+	// 		 void FileService_FileRemoved (object sender, FileEventArgs e)
+	// 		 {
+	// 		 	lock (watchedFiles) {
+	// 		 		foreach (var file in e) {
+	// 		 			if (watchedFiles.Remove (file.FileName)) {
+	// 		 				ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileDeleted));
+	// 		 				WatchDirectories ();
+	// 		 			}
+	// 		 		}
+	// 		 	}
+	// 		 }
 
-			void FileService_FileRemoved (object sender, FileEventArgs e)
-			{
-				lock (watchedFiles) {
-					foreach (var file in e) {
-						if (watchedFiles.Remove (file.FileName)) {
-							ConventionFileChanged?.Invoke (this, new ConventionsFileChangeEventArgs (file.FileName.FileName, file.FileName.ParentDirectory, ChangeType.FileDeleted));
-							WatchDirectories ();
-						}
-					}
-				}
-			}
+	// 	 	public void Dispose ()
+	// 	 	{
+	// 	 		FileService.FileMoved -= FileService_FileMoved;
+	// 	 		FileService.FileRenamed -= FileService_FileMoved;
+	// 	 		FileService.FileRemoved -= FileService_FileRemoved;
+	// 	 		FileService.FileChanged -= FileService_FileChanged;
+	// 	 		FileWatcherService.WatchDirectories (this, null).Ignore ();
+	// 	 		lock (watchedFiles) {
+	// 	 			watchedFiles = null;
+	// 	 		}
+	// 	 	}
 
-			public void Dispose ()
-			{
-				FileService.FileMoved -= FileService_FileMoved;
-				FileService.FileRenamed -= FileService_FileMoved;
-				FileService.FileRemoved -= FileService_FileRemoved;
-				FileService.FileChanged -= FileService_FileChanged;
-				FileWatcherService.WatchDirectories (this, null).Ignore ();
-				lock (watchedFiles) {
-					watchedFiles = null;
-				}
-			}
+	// 	 	public void StartWatching (string fileName, string directoryPath)
+	// 	 	{
+	// 	 		lock (watchedFiles) {
+	// 	 			var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
 
-			public void StartWatching (string fileName, string directoryPath)
-			{
-				lock (watchedFiles) {
-					var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
+	// 	 			if (!File.Exists (key))
+	// 	 				return;
 
-					if (!File.Exists (key))
-						return;
+	// 	 			if (!watchedFiles.Add (key))
+	// 	 				return;
 
-					if (!watchedFiles.Add (key))
-						return;
+	// 	 			WatchDirectories ();
+	// 	 		}
+	// 	 	}
 
-					WatchDirectories ();
-				}
-			}
+	// 	 	public void StopWatching (string fileName, string directoryPath)
+	// 	 	{
+	// 	 		lock (watchedFiles) {
+		
+	// 	 			var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
+	// 	 			if (watchedFiles.Remove (key)) {
+	// 	 				WatchDirectories ();
+	// 	 			}
+	// 	 		}
+	// 	 	}
 
-			public void StopWatching (string fileName, string directoryPath)
-			{
-				lock (watchedFiles) {
-					var key = directoryPath + Path.DirectorySeparatorChar.ToString () + fileName;
-					if (watchedFiles.Remove (key)) {
-						WatchDirectories ();
-					}
-				}
-			}
-
-			void WatchDirectories ()
-			{
-				var directories = watchedFiles.Count == 0 ? null : watchedFiles.Select (file => new FilePath (file).ParentDirectory);
-				FileWatcherService.WatchDirectories (this, directories).Ignore ();
-			}
-		}
-	}
-}
+	// 	 	void WatchDirectories ()
+	// 	 	{
+	// 	 		var directories = watchedFiles.Count == 0 ? null : watchedFiles.Select (file => new FilePath (file).ParentDirectory);
+	// 	 		FileWatcherService.WatchDirectories (this, directories).Ignore ();
+	// 	 	}
+	 //	 }
+	// }
+//}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1071,18 +1071,18 @@ namespace MonoDevelop.Ide.Editor
 
 		async void TextEditor_FileNameChanged (object sender, EventArgs e)
 		{
-			fileTypeCondition.SetFileName (FileName);
+			//fileTypeCondition.SetFileName (FileName);
 
 			// This is a sync call to remove from the cache, then async to dispose the context after the load is awaited.
-			EditorConfigService.RemoveEditConfigContext (FileName).Ignore ();
+			//EditorConfigService.RemoveEditConfigContext (FileName).Ignore ();
 
 			// There is no use to try and create a cached context if we won't use it.
-			if (!(Options is DefaultSourceEditorOptions options))
-				return;
+			//if (!(Options is DefaultSourceEditorOptions options))
+			//	return;
 
-			var context = await EditorConfigService.GetEditorConfigContext (FileName);
-			if (context != null)
-				options.SetContext (context);
+			//var context = await EditorConfigService.GetEditorConfigContext (FileName);
+			//if (context != null)
+			//	options.SetContext (context);
 		}
 
 		void TextEditor_MimeTypeChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -236,10 +236,10 @@ namespace MonoDevelop.Ide.Editor
 			policyContainer.PolicyChanged += HandlePolicyChanged;
 			((DefaultSourceEditorOptions)textEditor.Options).UpdateStylePolicy (currentPolicy);
 
-			var context = await EditorConfigService.GetEditorConfigContext (textEditor.FileName, token);
-			if (context == null)
-				return;
-			((DefaultSourceEditorOptions)textEditor.Options).SetContext (context);
+			//var context = await EditorConfigService.GetEditorConfigContext (textEditor.FileName, token);
+			//if (context == null)
+			// 	return;
+			// ((DefaultSourceEditorOptions)textEditor.Options).SetContext (context);
 		}
 
 		void HandlePolicyChanged (object sender, MonoDevelop.Projects.Policies.PolicyChangedEventArgs args)
@@ -379,7 +379,7 @@ namespace MonoDevelop.Ide.Editor
 				if (!string.IsNullOrEmpty (textEditorImpl.ContentName))
 					AutoSave.RemoveAutoSaveFile (textEditorImpl.ContentName);
 
-				EditorConfigService.RemoveEditConfigContext (textEditor.FileName).Ignore ();
+				//EditorConfigService.RemoveEditConfigContext (textEditor.FileName).Ignore ();
 				textEditorImpl.DirtyChanged -= HandleDirtyChanged;
 				textEditor.MimeTypeChanged -= UpdateTextEditorOptions;
 				textEditor.TextChanged -= HandleTextChanged;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
@@ -482,12 +482,12 @@ namespace MonoDevelop.Ide.Templates
 				: MonoDevelop.Projects.Policies.PolicyService.GetDefaultPolicy<TextStylePolicy> (mime ?? "text/plain");
 			string eolMarker = TextStylePolicy.GetEolMarker (textPolicy.EolMarker);
 
-			var ctx = await EditorConfigService.GetEditorConfigContext (fileName);
-			if (ctx != null) {
-				ctx.CurrentConventions.UniversalConventions.TryGetEncoding (out encoding);
-				if (ctx.CurrentConventions.UniversalConventions.TryGetLineEnding (out string lineEnding))
-					eolMarker = lineEnding;
-			}
+			// var ctx = await EditorConfigService.GetEditorConfigContext (fileName);
+			// if (ctx != null) {
+			// 	ctx.CurrentConventions.UniversalConventions.TryGetEncoding (out encoding);
+			// 	if (ctx.CurrentConventions.UniversalConventions.TryGetLineEnding (out string lineEnding))
+			// 		eolMarker = lineEnding;
+			// }
 			if (encoding == null)
 				encoding = System.Text.Encoding.UTF8;
 			var bom = encoding.GetPreamble ();
@@ -509,12 +509,12 @@ namespace MonoDevelop.Ide.Templates
 			bool convertTabsToSpaces = textPolicy.TabsToSpaces;
 			int tabWidth = textPolicy.TabWidth;
 
-			if (ctx != null) {
-				if (ctx.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
-					convertTabsToSpaces = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
-				if (ctx.CurrentConventions.UniversalConventions.TryGetTabWidth (out int editorConfigTabWidth))
-					tabWidth = editorConfigTabWidth;
-			}
+			//if (ctx != null) {
+				//if (ctx.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
+					//convertTabsToSpaces = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
+				//if (ctx.CurrentConventions.UniversalConventions.TryGetTabWidth (out int editorConfigTabWidth))
+			//		tabWidth = editorConfigTabWidth;
+			//}
 			var tabToSpaces = convertTabsToSpaces ? new string (' ', tabWidth) : null;
 
 			IDocumentLine lastLine = null;
@@ -529,13 +529,13 @@ namespace MonoDevelop.Ide.Templates
 				}
 				lastLine = line;
 			}
-			if (ctx != null && lastLine != null && lastLine.Length > 0) {
-				if (ctx.CurrentConventions.UniversalConventions.TryGetRequireFinalNewline (out bool requireNewLine)) {
-					if (requireNewLine)
-						ms.Write (eolMarkerBytes, 0, eolMarkerBytes.Length);
-				}
-			}
-			ctx.Dispose ();
+			//if (ctx != null && lastLine != null && lastLine.Length > 0) {
+			//	if (ctx.CurrentConventions.UniversalConventions.TryGetRequireFinalNewline (out bool requireNewLine)) {
+			//		if (requireNewLine)
+			//			ms.Write (eolMarkerBytes, 0, eolMarkerBytes.Length);
+			//	}
+			//}
+			//ctx.Dispose ();
 			ms.Position = 0;
 			return ms;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
@@ -482,12 +482,12 @@ namespace MonoDevelop.Ide.Templates
 				: MonoDevelop.Projects.Policies.PolicyService.GetDefaultPolicy<TextStylePolicy> (mime ?? "text/plain");
 			string eolMarker = TextStylePolicy.GetEolMarker (textPolicy.EolMarker);
 
-			// var ctx = await EditorConfigService.GetEditorConfigContext (fileName);
-			// if (ctx != null) {
-			// 	ctx.CurrentConventions.UniversalConventions.TryGetEncoding (out encoding);
-			// 	if (ctx.CurrentConventions.UniversalConventions.TryGetLineEnding (out string lineEnding))
-			// 		eolMarker = lineEnding;
-			// }
+			/* var ctx = await EditorConfigService.GetEditorConfigContext (fileName);
+			if (ctx != null) {
+				ctx.CurrentConventions.UniversalConventions.TryGetEncoding (out encoding);
+				if (ctx.CurrentConventions.UniversalConventions.TryGetLineEnding (out string lineEnding))
+					eolMarker = lineEnding;
+			} */
 			if (encoding == null)
 				encoding = System.Text.Encoding.UTF8;
 			var bom = encoding.GetPreamble ();
@@ -509,12 +509,12 @@ namespace MonoDevelop.Ide.Templates
 			bool convertTabsToSpaces = textPolicy.TabsToSpaces;
 			int tabWidth = textPolicy.TabWidth;
 
-			//if (ctx != null) {
-				//if (ctx.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
-					//convertTabsToSpaces = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
-				//if (ctx.CurrentConventions.UniversalConventions.TryGetTabWidth (out int editorConfigTabWidth))
-			//		tabWidth = editorConfigTabWidth;
-			//}
+			/* if (ctx != null) {
+				if (ctx.CurrentConventions.UniversalConventions.TryGetIndentStyle (out Microsoft.VisualStudio.CodingConventions.IndentStyle result))
+					convertTabsToSpaces = result == Microsoft.VisualStudio.CodingConventions.IndentStyle.Spaces;
+				if (ctx.CurrentConventions.UniversalConventions.TryGetTabWidth (out int editorConfigTabWidth))
+					tabWidth = editorConfigTabWidth;
+			} */
 			var tabToSpaces = convertTabsToSpaces ? new string (' ', tabWidth) : null;
 
 			IDocumentLine lastLine = null;
@@ -529,13 +529,13 @@ namespace MonoDevelop.Ide.Templates
 				}
 				lastLine = line;
 			}
-			//if (ctx != null && lastLine != null && lastLine.Length > 0) {
-			//	if (ctx.CurrentConventions.UniversalConventions.TryGetRequireFinalNewline (out bool requireNewLine)) {
-			//		if (requireNewLine)
-			//			ms.Write (eolMarkerBytes, 0, eolMarkerBytes.Length);
-			//	}
-			//}
-			//ctx.Dispose ();
+			/* if (ctx != null && lastLine != null && lastLine.Length > 0) {
+				if (ctx.CurrentConventions.UniversalConventions.TryGetRequireFinalNewline (out bool requireNewLine)) {
+					if (requireNewLine)
+						ms.Write (eolMarkerBytes, 0, eolMarkerBytes.Length);
+				}
+			}
+			ctx.Dispose (); */
 			ms.Position = 0;
 			return ms;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -55,7 +55,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="$(NuGetVersionMicrosoftTemplateEngine)" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(NuGetVersionMicrosoftTemplateEngine)" PrivateAssets="runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" PrivateAssets="runtime" />
+    <!--<PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" PrivateAssets="runtime" />-->
     <PackageReference Include="YamlDotNet" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/EditorConfigTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/EditorConfigTests.cs
@@ -24,165 +24,165 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System.IO;
-using NUnit.Framework;
-using UnitTests;
-using System.Threading;
-using GuiUnit;
-using System;
-using System.Threading.Tasks;
-using MonoDevelop.Ide.TextEditing;
+// using System.IO;
+// using NUnit.Framework;
+// using UnitTests;
+// using System.Threading;
+// using GuiUnit;
+// using System;
+// using System.Threading.Tasks;
+// using MonoDevelop.Ide.TextEditing;
 
-namespace MonoDevelop.Ide.Editor
-{
-	[TestFixture]
-	[RequireService(typeof(TextEditorService))]
-	class EditorConfigTests : IdeTestBase
-	{
+// namespace MonoDevelop.Ide.Editor
+// {
+// 	[TestFixture]
+// 	[RequireService(typeof(TextEditorService))]
+// 	class EditorConfigTests : IdeTestBase
+// 	{
 
-		static async Task InvokeEditConfigTest (string editConfig, Action<TextEditor> test)
-		{
-			string tempPath;
-			int i = 0;
-			while (true) {
-				tempPath = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
-				if (!File.Exists (tempPath))
-					break;
-				if (i++ > 100)
-					Assert.Fail ("Can't create random path.");
-			}
+// 		static async Task InvokeEditConfigTest (string editConfig, Action<TextEditor> test)
+// 		{
+// 			string tempPath;
+// 			int i = 0;
+// 			while (true) {
+// 				tempPath = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+// 				if (!File.Exists (tempPath))
+// 					break;
+// 				if (i++ > 100)
+// 					Assert.Fail ("Can't create random path.");
+// 			}
 
-			Directory.CreateDirectory (tempPath);
-			try {
-				string editorConfigFile = Path.Combine (tempPath, ".editorconfig");
-				File.WriteAllText (editorConfigFile, editConfig);
-				var editor = TextEditorFactory.CreateNewEditor ();
-				string fileName = Path.Combine (tempPath, "a.cs");
-				try {
-					using (var ctx = await EditorConfigService.GetEditorConfigContext (fileName)) {
-						((DefaultSourceEditorOptions)editor.Options).SetContext (ctx);
-						test (editor);
-					}
-				} finally {
-					await EditorConfigService.RemoveEditConfigContext (fileName);
-				}
-			} finally {
-				Directory.Delete (tempPath, true);
-			}
-		}
+// 			Directory.CreateDirectory (tempPath);
+// 			try {
+// 				string editorConfigFile = Path.Combine (tempPath, ".editorconfig");
+// 				File.WriteAllText (editorConfigFile, editConfig);
+// 				var editor = TextEditorFactory.CreateNewEditor ();
+// 				string fileName = Path.Combine (tempPath, "a.cs");
+// 				try {
+// 					using (var ctx = await EditorConfigService.GetEditorConfigContext (fileName)) {
+// 						((DefaultSourceEditorOptions)editor.Options).SetContext (ctx);
+// 						test (editor);
+// 					}
+// 				} finally {
+// 					await EditorConfigService.RemoveEditConfigContext (fileName);
+// 				}
+// 			} finally {
+// 				Directory.Delete (tempPath, true);
+// 			}
+// 		}
 
-		[Test]
-		public async Task Test_indent_style ()
-		{
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-indent_style = space
-", editor => {
-				Assert.AreEqual (true, editor.Options.TabsToSpaces);
-			});
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-indent_style = tab
-", editor => {
-				Assert.AreEqual (false, editor.Options.TabsToSpaces);
-			});
-		}
+// 		[Test]
+// 		public async Task Test_indent_style ()
+// 		{
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// indent_style = space
+// ", editor => {
+// 				Assert.AreEqual (true, editor.Options.TabsToSpaces);
+// 			});
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// indent_style = tab
+// ", editor => {
+// 				Assert.AreEqual (false, editor.Options.TabsToSpaces);
+// 			});
+// 		}
 
-		[Test]
-		public async Task Test_indent_size ()
-		{
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-indent_size = 42
-", editor => {
-				Assert.AreEqual (42, editor.Options.IndentationSize);
-			});
-		}
+// 		[Test]
+// 		public async Task Test_indent_size ()
+// 		{
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// indent_size = 42
+// ", editor => {
+// 				Assert.AreEqual (42, editor.Options.IndentationSize);
+// 			});
+// 		}
 
-		[Test]
-		public async Task Test_tab_width ()
-		{
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-tab_width = 42
-", editor => {
-				Assert.AreEqual (42, editor.Options.TabSize);
-			});
-		}
+// 		[Test]
+// 		public async Task Test_tab_width ()
+// 		{
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// tab_width = 42
+// ", editor => {
+// 				Assert.AreEqual (42, editor.Options.TabSize);
+// 			});
+// 		}
 
-		[Test]
-		public async Task Test_end_of_line ()
-		{
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-end_of_line = lf
-", editor => {
-				Assert.AreEqual ("\n", editor.Options.DefaultEolMarker);
-			});
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-end_of_line = cr
-", editor => {
-				Assert.AreEqual ("\r", editor.Options.DefaultEolMarker);
-			});
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-end_of_line = crlf
-", editor => {
-				Assert.AreEqual ("\r\n", editor.Options.DefaultEolMarker);
-			});
-		}
+// 		[Test]
+// 		public async Task Test_end_of_line ()
+// 		{
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// end_of_line = lf
+// ", editor => {
+// 				Assert.AreEqual ("\n", editor.Options.DefaultEolMarker);
+// 			});
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// end_of_line = cr
+// ", editor => {
+// 				Assert.AreEqual ("\r", editor.Options.DefaultEolMarker);
+// 			});
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// end_of_line = crlf
+// ", editor => {
+// 				Assert.AreEqual ("\r\n", editor.Options.DefaultEolMarker);
+// 			});
+// 		}
 
-		[Test]
-		public async Task Test_trim_trailing_whitespace ()
-		{
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-trim_trailing_whitespace = true
-", editor => {
-				Assert.AreEqual (true, editor.Options.RemoveTrailingWhitespaces);
-			});
+// 		[Test]
+// 		public async Task Test_trim_trailing_whitespace ()
+// 		{
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// trim_trailing_whitespace = true
+// ", editor => {
+// 				Assert.AreEqual (true, editor.Options.RemoveTrailingWhitespaces);
+// 			});
 
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-trim_trailing_whitespace = false
-", editor => {
-				Assert.AreEqual (false, editor.Options.RemoveTrailingWhitespaces);
-			});
-		}
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// trim_trailing_whitespace = false
+// ", editor => {
+// 				Assert.AreEqual (false, editor.Options.RemoveTrailingWhitespaces);
+// 			});
+// 		}
 
-		[Test]
-		public async Task Test_max_line_length ()
-		{
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-max_line_length = off
-", editor => {
-				Assert.AreEqual (false, editor.Options.ShowRuler);
-			});
+// 		[Test]
+// 		public async Task Test_max_line_length ()
+// 		{
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// max_line_length = off
+// ", editor => {
+// 				Assert.AreEqual (false, editor.Options.ShowRuler);
+// 			});
 
-			await InvokeEditConfigTest (@"
-root = true
-[*.cs]
-max_line_length = 42
-", editor => {
-				Assert.AreEqual (true, editor.Options.ShowRuler);
-				Assert.AreEqual (42, editor.Options.RulerColumn);
-			});
-		}
-
-
+// 			await InvokeEditConfigTest (@"
+// root = true
+// [*.cs]
+// max_line_length = 42
+// ", editor => {
+// 				Assert.AreEqual (true, editor.Options.ShowRuler);
+// 				Assert.AreEqual (42, editor.Options.RulerColumn);
+// 			});
+// 		}
 
 
-	}
-}
+
+
+// 	}
+// }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/EditorConfigTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/EditorConfigTests.cs
@@ -24,165 +24,166 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// using System.IO;
-// using NUnit.Framework;
-// using UnitTests;
-// using System.Threading;
-// using GuiUnit;
-// using System;
-// using System.Threading.Tasks;
-// using MonoDevelop.Ide.TextEditing;
+/* using System.IO;
+using NUnit.Framework;
+using UnitTests;
+using System.Threading;
+using GuiUnit;
+using System;
+using System.Threading.Tasks;
+using MonoDevelop.Ide.TextEditing;
 
-// namespace MonoDevelop.Ide.Editor
-// {
-// 	[TestFixture]
-// 	[RequireService(typeof(TextEditorService))]
-// 	class EditorConfigTests : IdeTestBase
-// 	{
+namespace MonoDevelop.Ide.Editor
+{
+	[TestFixture]
+	[RequireService(typeof(TextEditorService))]
+	class EditorConfigTests : IdeTestBase
+	{
 
-// 		static async Task InvokeEditConfigTest (string editConfig, Action<TextEditor> test)
-// 		{
-// 			string tempPath;
-// 			int i = 0;
-// 			while (true) {
-// 				tempPath = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
-// 				if (!File.Exists (tempPath))
-// 					break;
-// 				if (i++ > 100)
-// 					Assert.Fail ("Can't create random path.");
-// 			}
+		static async Task InvokeEditConfigTest (string editConfig, Action<TextEditor> test)
+		{
+			string tempPath;
+			int i = 0;
+			while (true) {
+				tempPath = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+				if (!File.Exists (tempPath))
+					break;
+				if (i++ > 100)
+					Assert.Fail ("Can't create random path.");
+			}
 
-// 			Directory.CreateDirectory (tempPath);
-// 			try {
-// 				string editorConfigFile = Path.Combine (tempPath, ".editorconfig");
-// 				File.WriteAllText (editorConfigFile, editConfig);
-// 				var editor = TextEditorFactory.CreateNewEditor ();
-// 				string fileName = Path.Combine (tempPath, "a.cs");
-// 				try {
-// 					using (var ctx = await EditorConfigService.GetEditorConfigContext (fileName)) {
-// 						((DefaultSourceEditorOptions)editor.Options).SetContext (ctx);
-// 						test (editor);
-// 					}
-// 				} finally {
-// 					await EditorConfigService.RemoveEditConfigContext (fileName);
-// 				}
-// 			} finally {
-// 				Directory.Delete (tempPath, true);
-// 			}
-// 		}
+			Directory.CreateDirectory (tempPath);
+			try {
+				string editorConfigFile = Path.Combine (tempPath, ".editorconfig");
+				File.WriteAllText (editorConfigFile, editConfig);
+				var editor = TextEditorFactory.CreateNewEditor ();
+				string fileName = Path.Combine (tempPath, "a.cs");
+				try {
+					using (var ctx = await EditorConfigService.GetEditorConfigContext (fileName)) {
+						((DefaultSourceEditorOptions)editor.Options).SetContext (ctx);
+						test (editor);
+					}
+				} finally {
+					await EditorConfigService.RemoveEditConfigContext (fileName);
+				}
+			} finally {
+				Directory.Delete (tempPath, true);
+			}
+		}
 
-// 		[Test]
-// 		public async Task Test_indent_style ()
-// 		{
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// indent_style = space
-// ", editor => {
-// 				Assert.AreEqual (true, editor.Options.TabsToSpaces);
-// 			});
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// indent_style = tab
-// ", editor => {
-// 				Assert.AreEqual (false, editor.Options.TabsToSpaces);
-// 			});
-// 		}
+		[Test]
+		public async Task Test_indent_style ()
+		{
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+indent_style = space
+", editor => {
+				Assert.AreEqual (true, editor.Options.TabsToSpaces);
+			});
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+indent_style = tab
+", editor => {
+				Assert.AreEqual (false, editor.Options.TabsToSpaces);
+			});
+		}
 
-// 		[Test]
-// 		public async Task Test_indent_size ()
-// 		{
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// indent_size = 42
-// ", editor => {
-// 				Assert.AreEqual (42, editor.Options.IndentationSize);
-// 			});
-// 		}
+		[Test]
+		public async Task Test_indent_size ()
+		{
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+indent_size = 42
+", editor => {
+				Assert.AreEqual (42, editor.Options.IndentationSize);
+			});
+		}
 
-// 		[Test]
-// 		public async Task Test_tab_width ()
-// 		{
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// tab_width = 42
-// ", editor => {
-// 				Assert.AreEqual (42, editor.Options.TabSize);
-// 			});
-// 		}
+		[Test]
+		public async Task Test_tab_width ()
+		{
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+tab_width = 42
+", editor => {
+				Assert.AreEqual (42, editor.Options.TabSize);
+			});
+		}
 
-// 		[Test]
-// 		public async Task Test_end_of_line ()
-// 		{
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// end_of_line = lf
-// ", editor => {
-// 				Assert.AreEqual ("\n", editor.Options.DefaultEolMarker);
-// 			});
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// end_of_line = cr
-// ", editor => {
-// 				Assert.AreEqual ("\r", editor.Options.DefaultEolMarker);
-// 			});
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// end_of_line = crlf
-// ", editor => {
-// 				Assert.AreEqual ("\r\n", editor.Options.DefaultEolMarker);
-// 			});
-// 		}
+		[Test]
+		public async Task Test_end_of_line ()
+		{
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+end_of_line = lf
+", editor => {
+				Assert.AreEqual ("\n", editor.Options.DefaultEolMarker);
+			});
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+end_of_line = cr
+", editor => {
+				Assert.AreEqual ("\r", editor.Options.DefaultEolMarker);
+			});
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+end_of_line = crlf
+", editor => {
+				Assert.AreEqual ("\r\n", editor.Options.DefaultEolMarker);
+			});
+		}
 
-// 		[Test]
-// 		public async Task Test_trim_trailing_whitespace ()
-// 		{
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// trim_trailing_whitespace = true
-// ", editor => {
-// 				Assert.AreEqual (true, editor.Options.RemoveTrailingWhitespaces);
-// 			});
+		[Test]
+		public async Task Test_trim_trailing_whitespace ()
+		{
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+trim_trailing_whitespace = true
+", editor => {
+				Assert.AreEqual (true, editor.Options.RemoveTrailingWhitespaces);
+			});
 
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// trim_trailing_whitespace = false
-// ", editor => {
-// 				Assert.AreEqual (false, editor.Options.RemoveTrailingWhitespaces);
-// 			});
-// 		}
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+trim_trailing_whitespace = false
+", editor => {
+				Assert.AreEqual (false, editor.Options.RemoveTrailingWhitespaces);
+			});
+		}
 
-// 		[Test]
-// 		public async Task Test_max_line_length ()
-// 		{
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// max_line_length = off
-// ", editor => {
-// 				Assert.AreEqual (false, editor.Options.ShowRuler);
-// 			});
+		[Test]
+		public async Task Test_max_line_length ()
+		{
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+max_line_length = off
+", editor => {
+				Assert.AreEqual (false, editor.Options.ShowRuler);
+			});
 
-// 			await InvokeEditConfigTest (@"
-// root = true
-// [*.cs]
-// max_line_length = 42
-// ", editor => {
-// 				Assert.AreEqual (true, editor.Options.ShowRuler);
-// 				Assert.AreEqual (42, editor.Options.RulerColumn);
-// 			});
-// 		}
-
-
+			await InvokeEditConfigTest (@"
+root = true
+[*.cs]
+max_line_length = 42
+", editor => {
+				Assert.AreEqual (true, editor.Options.ShowRuler);
+				Assert.AreEqual (42, editor.Options.RulerColumn);
+			});
+		}
 
 
-// 	}
-// }
+
+
+	}
+}
+ */


### PR DESCRIPTION
Remove nuget package Microsoft.VisualStudio.CodingConventions
Since https://github.com/dotdevelop/dotdevelop/issues/112 where a package is not avilable any more, I have commented that code out that it is building now without it. Maybe it is useful? Hope I commented out everything where it is downloaded. There needs to be much to comment out, but do we have an alternative? I have not tested if there are crashes and what features are missing.