### PR TITLE
Update build docs for Windows

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -4,7 +4,30 @@ To build DotDevelop from scratch you will need to following pre-requisites.
 
 Please note, Ubuntu 20.04 LTS is the perferred environment for buiding from source as Ubuntu 22.04 LTS doesn’t support .NET Core 3.1 or 2.0 since the distro only supports openSSL 3.
 
-## Build Environment Requirements
+## Windows
+
+### Prerequisites
+
+* Install Visual Studio 2017 (_2019, or 2022_) with the .NET Desktop and .NET Core workloads and the F# optional component (note, F# is disabled by default so need to enable it in the VS installer).
+* Install Git for Windows (from [here](https://git-for-windows.github.io/))
+* Make sure you have .NET Framework 4.7.1 Reference Assemblies ([4.7.1 Targeting Pack](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net471))
+* Install Gtk# ([installer](https://www.mono-project.com/download/stable/)). Direct link: gtk-sharp-2.12.45.msi
+* Install the Mono libraries package (installer)
+* Install GNU Gettext tools (from here)
+
+### Build Steps
+
+Open a command prompt
+
+1. Clone the repository, `https://github.com/dotdevelop/dotdevelop.git`
+   1. `cd DotDevelop`
+2. `git submodule update --init --recursive`
+3. Build the project
+   1. `./main/winbuild.bat`  (Powershell)
+
+## Linux
+
+### Build Environment Requirements
 
 The following steps are for Ubuntu, other distros may require different URLs.
 
@@ -56,7 +79,7 @@ sudo apt install curl
 sudo apt install -y cmake clang
 ```
 
-## Clone and Building
+### Clone and Building
 
 Build DotDevelop
 
@@ -77,7 +100,7 @@ bash build.sh
 cd ../../..
 ```
 
-## Launching the IDE
+### Launching the IDE
 
 Launch DotDevelop, using one of the 2 options
 
@@ -89,29 +112,28 @@ Launch DotDevelop, using one of the 2 options
 mono main/build/bin/MonoDevelop.exe
 ```
 
-### Verify .NET Core Debugger is attached
+## Verify .NET Core Debugger is attached
 
 1. Launch, MonoDevelop
 2. Edit > Preferences > Projects > .NET Core Debuggers
 3. Click `...` and navigate to, `main/build/AddIns/Samsung.Netcoredbg/netcoredbg`
-4. Click, OK and start debugging  
+4. Click, OK and start debugging
 
+## Running DotDevelop with .NET6.0+ installed
 
-### Running DotDevelop with .NET6.0+ installed
+With dotnet-sdk-6.0+ installed, the following error occurs:-
 
-With dotnet-sdk-6.0+ installed, the following error occurs:-  
+"MSB4236 WorkloadAutoImportPropsLocator could not be found".
 
-"MSB4236 WorkloadAutoImportPropsLocator could not be found".  
+This is described by  [this issue](https://github.com/dotnet/sdk/issues/17461) with the following workaround:-
 
-This is described by  [this issue](https://github.com/dotnet/sdk/issues/17461) with the following workaround:-   
+Set the environment variable `MSBuildEnableWorkloadResolver=false` prior to starting monodevelop
 
-Set the environment variable `MSBuildEnableWorkloadResolver=false` prior to starting monodevelop  
+eg, in a terminal, before starting dotdevelop as above...
 
-eg, in a terminal, before starting dotdevelop as above...   
-  
 ```bash
 export MSBuildEnableWorkloadResolver=false
-mono ./main/build/bin/MonoDevelop.exe --no-redirect 
+mono ./main/build/bin/MonoDevelop.exe --no-redirect
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@ This is an effort to get MonoDevelop open sourced again.
 
 **DotDevelop** will hopefully be a full-featured integrated development environment (IDE) for .NET using GTK.
 
-**Current Status**
+## Current Status
 
 This fork is based on the last commit on 29 Jan 2020 (https://github.com/mono/monodevelop/commit/96b42aa0741af179a8e501f426b6ff5451c27264).
 
 It was refactored to compile / run again on Linux. Other platforms will follow.
 
-**Contributors**
+## Contributors
 
 To hack around, use a Ubuntu 20.04 machine and follow the steps below,
 
 1. Acquire all dependencies,
 
-```
+```sh
 sudo apt install intltool fsharp gtk-sharp2
 ```
 
 2. Check out the code and compile,
 
-```
+```sh
 git clone -b main https://github.com/dotdevelop/dotdevelop.git
 
 cd dotdevelop/
@@ -30,7 +30,6 @@ cd dotdevelop/
 ./configure --profile=gnome
 
 make
-
 ```
 
 > Take a look at [the CI manifest](https://github.com/dotdevelop/dotdevelop/blob/main/.github/workflows/monodevelop.yml) in case the latest steps differ from above.
@@ -40,21 +39,18 @@ make
 
 # (outdated) ReadMe from MonoDevelop:
 
-Directory organization
-----------------------
+## Directory organization
 
 There are two main directories:
 
- * `main`: The core MonoDevelop assemblies and add-ins (all in a single
-    tarball/package).
- * `extras`: Additional add-ins (each add-in has its own
-    tarball/package).
+* `main`: The core MonoDevelop assemblies and add-ins (all in a single tarball/package).
+* `extras`: Additional add-ins (each add-in has its own tarball/package).
 
-Compiling
----------
+## Compiling
 
 If you are building from Git, make sure that you initialize the submodules
 that are part of this repository by executing:
+
 `git submodule update --init --recursive`
 
 If you are running a parallel mono installation, make sure to run all the following steps
@@ -67,7 +63,6 @@ To compile execute:
 There are two variables you can set when running `configure`:
 
 * The install prefix: `--prefix=/path/to/prefix`
-
   * To install with the rest of the assemblies, use:
   `--prefix="pkg-config --variable=prefix mono"`
 
@@ -82,46 +77,39 @@ There are two variables you can set when running `configure`:
 
 Disclaimer: Please be aware that the 'extras/JavaBinding' and 'extras/ValaBinding' packages do not currently work. When prompted or by manually selecting them during the './configure --select' step, make sure they stay deselected. (deselected by default)
 
-Running
--------
+## Running
 
 You can run MonoDevelop from the build directory by executing:
 `make run`
 
-Debugging
----------
+## Debugging
 
 You can debug MonoDevelop using Visual Studio (on Windows or macOS) with the
 `main/Main.sln` solution. Use the `DebugWin32` configuration on Windows and the
 `DebugMac` configuration on macOS.
 
-Installing *(Optional)*
-----------
+## Installing *(Optional)*
 
 You can install MonoDevelop by running:
 `make install`
 
 Bear in mind that if you are installing under a custom prefix, you may need to modify your `/etc/ld.so.conf` or `LD_LIBRARY_PATH` to ensure that any required native libraries are found correctly.
 
-*(It's possible that you need to install for your locale to be
-correctly set.)*
+*(It's possible that you need to install for your locale to be correctly set.)*
 
-Packaging for OS X
------------------
+## Packaging for OS X
 
 To package MonoDevelop for OS X in a convenient MonoDevelop.app
 file, just do this after MonoDevelop has finished building (with
 `make`): `cd main/build/MacOSX ; make app`.
 You can run MonoDevelop: `open MonoDevelop.app` or build dmg package: `./make-dmg-bundle.sh`
 
-Dependencies
-------------
+## Dependencies
 
-- [Windows](https://github.com/mono/md-website/blob/gh-pages/developers/building-monodevelop.md#prerequisites-and-source)
-- [Unix](http://www.monodevelop.com/developers/building-monodevelop/#linux)
+* [Windows](https://github.com/mono/md-website/blob/gh-pages/developers/building-monodevelop.md#prerequisites-and-source)
+* [Unix](http://www.monodevelop.com/developers/building-monodevelop/#linux)
 
-Special Environment Variables
------------------------------
+## Special Environment Variables
 
 **BUILD_REVISION**
 
@@ -129,11 +117,9 @@ Special Environment Variables
 	We use this to enable raygun only for 'release' builds and not for normal
 	developer builds compiled on a dev machine with 'make && make run'.
 
+## Known Problems
 
-Known Problems
------------------------------
-
-```
+```txt
 "The type `GLib.IIcon' is defined in an assembly that is not referenced"
 ```
 
@@ -143,20 +129,13 @@ Make sure to 'make uninstall' or otherwise remove the gtk-sharp3 version and ins
 xbuild may still cache a reference to assemblies that you may have accidentally installed into your mono installation,
 like the gtk-sharp3 as described before. You can delete the cache in $HOME/.config/xbuild/pkgconfig-cache-2.xml
 
+## References
 
+* **[MonoDevelop website](http://www.monodevelop.com)**
+* **[Gnome Human Interface Guidelines (HIG)](https://developer.gnome.org/hig/stable/)**
+* **[freedesktop.org standards](http://freedesktop.org/Standards/)**
 
-References
-----------
-
-**[MonoDevelop website](http://www.monodevelop.com)**
-
-**[Gnome Human Interface Guidelines (HIG)](https://developer.gnome.org/hig/stable/)**
-
-**[freedesktop.org standards](http://freedesktop.org/Standards/)**
-
-Discussion, Bugs, Patches
--------------------------
+## Discussion, Bugs, Patches
 
 https://github.com/dotdevelop/dotdevelop/issues/new *(submit bugs and patches here)*
 https://github.com/dotdevelop/community/issues/9 *(temporary link to the roadmap thread, should be replaced in the future with a proper roadmap)
-

--- a/main/winbuild.bat
+++ b/main/winbuild.bat
@@ -1,6 +1,9 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
 
+REM Ensure we're executing from this directory
+cd /D "%~dp0"
+
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
 	FOR /F "delims=" %%E in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\installer\vswhere.exe" -latest -property installationPath') DO (
 		set "MSBUILD_EXE=%%E\MSBuild\Current\Bin\MSBuild.exe"
@@ -11,6 +14,8 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
 )
 
 FOR %%E in (Enterprise, Professional, Community) DO (
+	set "MSBUILD_EXE=%ProgramFiles%\Microsoft Visual Studio\2022\%%E\MSBuild\Current\Bin\MSBuild.exe"
+	if exist "!MSBUILD_EXE!" goto :build
 	set "MSBUILD_EXE=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\%%E\MSBuild\Current\Bin\MSBuild.exe"
 	if exist "!MSBUILD_EXE!" goto :build
 	set "MSBUILD_EXE=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\%%E\MSBuild\15.0\Bin\MSBuild.exe"
@@ -37,8 +42,13 @@ exit /b 1
 
 :build
 
+echo Using MSBuild: '%MSBUILD_EXE%'
+echo Syncing Git Submodules...
+
 git submodule sync || goto :error
 git submodule update --init --recursive || goto :error
+
+echo Restoring solution...
 "external\nuget-binary\NuGet.exe" restore Main.sln
 
 "%MSBUILD_EXE%" external\fsharpbinding\.paket\paket.targets /t:RestorePackages /p:PaketReferences="%~dp0external\fsharpbinding\MonoDevelop.FSharpBinding\paket.references"
@@ -46,6 +56,7 @@ git submodule update --init --recursive || goto :error
 if not defined CONFIG (set "CONFIG=DebugWin32")
 set "PLATFORM=Any CPU"
 
+echo Building solution...
 "%MSBUILD_EXE%" Main.sln /bl:MonoDevelop.binlog /r /m "/p:Configuration=%CONFIG%" "/p:Platform=%PLATFORM%" %* || goto :error
 goto :eof
 


### PR DESCRIPTION
The `Building.md` file was initially made for Ubuntu 20.04, however, I should have expanded it for Windows as well.

Feature includes:
* Updated readme.md markdown formatting
* Building.md - Added Building for Windows
* WinBuild.bat - Added VS2022 and echo output for stages