### PR TITLE
remove vs-editor-core reference

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -5,7 +5,7 @@
     <RootDirectory>$(MSBuildThisFileDirectory)</RootDirectory>
     <PackagesDirectory>$(RootDirectory)packages</PackagesDirectory>
     <MdAddinsDirectory>$(MSBuildThisFileDirectory)..\..\md-addins\</MdAddinsDirectory>
-    <VSEditorCoreDirectory Condition="'$(VSEditorCoreDirectory)' == ''">$(MdAddinsDirectory)external\vs-editor-core\</VSEditorCoreDirectory>
+    <!--<VSEditorCoreDirectory Condition="'$(VSEditorCoreDirectory)' == ''">$(MdAddinsDirectory)external\vs-editor-core\</VSEditorCoreDirectory>-->
     <VSEditorApiDirectory Condition="'$(VSEditorApiDirectory)' == ''">$(MSBuildThisFileDirectory)external\vs-editor-api\</VSEditorApiDirectory>
     <ReferencesVSEditor Condition=" '$(OS)' == 'Windows_NT' ">$(RootDirectory)\msbuild\ReferencesVSEditor.Windows.props</ReferencesVSEditor>
     <ReferencesVSEditor Condition=" '$(OS)' == 'MAC' ">$(RootDirectory)\msbuild\ReferencesVSEditor.Mac.props</ReferencesVSEditor>


### PR DESCRIPTION
I think this line can be deletet because external\vs-editor-core\ does not exist and is not open Source. It was never Open Source.

Github actions does not fail when commenting this out but this need to be tested if we have some bugs now or it simple can be removed.

