### PR TITLE
Update some nuget versions

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -11,7 +11,7 @@
     <ReferencesVSEditor Condition=" '$(OS)' == 'MAC' ">$(RootDirectory)\msbuild\ReferencesVSEditor.Mac.props</ReferencesVSEditor>
     <ReferencesVSEditor Condition=" '$(OS)' == 'UNIX' ">$(RootDirectory)\msbuild\ReferencesVSEditor.Gtk.props</ReferencesVSEditor>
     <ReferencesGtk>$(RootDirectory)\msbuild\ReferencesGtk.props</ReferencesGtk>
-    <NuGetVersionAllocationAnalyzer>1.0.0.9</NuGetVersionAllocationAnalyzer>
+    <NuGetVersionAllocationAnalyzer>3.0.0</NuGetVersionAllocationAnalyzer>
     <NuGetVersionCecil>0.10.4</NuGetVersionCecil>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
     <NuGetVersionMicrosoftTemplateEngine>3.0.0-rc1.19464.2</NuGetVersionMicrosoftTemplateEngine>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -17,12 +17,12 @@
     <NuGetVersionMicrosoftTemplateEngine>3.0.0-rc1.19464.2</NuGetVersionMicrosoftTemplateEngine>
     <NuGetVersionMicrosoftTestPlatform>16.2.0</NuGetVersionMicrosoftTestPlatform>
     <NuGetVersionMonoDevelopAnalyzers>0.1.0.2</NuGetVersionMonoDevelopAnalyzers>
-    <NuGetVersionNewtonsoftJson>12.0.2</NuGetVersionNewtonsoftJson>
+    <NuGetVersionNewtonsoftJson>13.0.3</NuGetVersionNewtonsoftJson>
     <NuGetVersionNuGet>5.8.0</NuGetVersionNuGet>
-    <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
-    <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>
+    <NuGetVersionNUnit2>2.7.1</NuGetVersionNUnit2>
+    <NuGetVersionNUnit3>3.16.3</NuGetVersionNUnit3>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
-    <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
+    <NuGetVersionVSComposition>17.7.26</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.4.280</NuGetVersionVSEditor>
   </PropertyGroup>
 </Project>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -21,7 +21,7 @@
     <NuGetVersionNuGet>5.8.0</NuGetVersionNuGet>
     <NuGetVersionNUnit2>2.7.1</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.16.3</NuGetVersionNUnit3>
-    <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
+    <NuGetVersionVSCodeDebugProtocol>17.2.60629.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>17.7.26</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.4.280</NuGetVersionVSEditor>
   </PropertyGroup>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -14,7 +14,7 @@
     <NuGetVersionAllocationAnalyzer>3.0.0</NuGetVersionAllocationAnalyzer>
     <NuGetVersionCecil>0.10.4</NuGetVersionCecil>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
-    <NuGetVersionMicrosoftTemplateEngine>3.0.0-rc1.19464.2</NuGetVersionMicrosoftTemplateEngine>
+    <NuGetVersionMicrosoftTemplateEngine>5.0.403</NuGetVersionMicrosoftTemplateEngine>
     <NuGetVersionMicrosoftTestPlatform>16.2.0</NuGetVersionMicrosoftTestPlatform>
     <NuGetVersionMonoDevelopAnalyzers>0.1.0.2</NuGetVersionMonoDevelopAnalyzers>
     <NuGetVersionNewtonsoftJson>13.0.3</NuGetVersionNewtonsoftJson>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -15,7 +15,7 @@
     <NuGetVersionCecil>0.10.4</NuGetVersionCecil>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
     <NuGetVersionMicrosoftTemplateEngine>5.0.403</NuGetVersionMicrosoftTemplateEngine>
-    <NuGetVersionMicrosoftTestPlatform>16.2.0</NuGetVersionMicrosoftTestPlatform>
+    <NuGetVersionMicrosoftTestPlatform>16.11.0</NuGetVersionMicrosoftTestPlatform>
     <NuGetVersionMonoDevelopAnalyzers>0.1.0.2</NuGetVersionMonoDevelopAnalyzers>
     <NuGetVersionNewtonsoftJson>13.0.3</NuGetVersionNewtonsoftJson>
     <NuGetVersionNuGet>5.8.0</NuGetVersionNuGet>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -12,7 +12,7 @@
     <ReferencesVSEditor Condition=" '$(OS)' == 'UNIX' ">$(RootDirectory)\msbuild\ReferencesVSEditor.Gtk.props</ReferencesVSEditor>
     <ReferencesGtk>$(RootDirectory)\msbuild\ReferencesGtk.props</ReferencesGtk>
     <NuGetVersionAllocationAnalyzer>1.0.0.9</NuGetVersionAllocationAnalyzer>
-    <NuGetVersionCecil>0.10.1</NuGetVersionCecil>
+    <NuGetVersionCecil>0.10.4</NuGetVersionCecil>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
     <NuGetVersionMicrosoftTemplateEngine>3.0.0-rc1.19464.2</NuGetVersionMicrosoftTemplateEngine>
     <NuGetVersionMicrosoftTestPlatform>16.2.0</NuGetVersionMicrosoftTestPlatform>

--- a/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
+++ b/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
@@ -4,7 +4,7 @@
     <OutDir>bin</OutDir>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.3" />
     <PackageReference Include="System.IO.Compression" Version="4.0.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NuGetVersionNewtonsoftJson)" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoDevelop.AspNetCore.Templating\AspNetCoreFileTemplateCondition.cs" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -26,10 +26,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.PackageManagement" Version="$(NuGetVersionNuGet)" PrivateAssets="runtime" />
-    <PackageReference Include="Castle.Core" Version="4.2.1" PrivateAssets="runtime" />
-    <PackageReference Include="Moq" Version="4.7.145" PrivateAssets="runtime" />
+    <PackageReference Include="Castle.Core" Version="5.1.1" PrivateAssets="runtime" />
+    <PackageReference Include="Moq" Version="4.20.69" PrivateAssets="runtime" />
     <!-- Ensure .NET 4.7.2's System.Net.Http is used not the one from this NuGet package -->
-    <PackageReference Include="System.Net.Http" Version="4.3.3" ExcludeAssets="all" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetVersionNuGet)" PrivateAssets="runtime" />
     <PackageReference Include="NuGet.Indexing" Version="$(NuGetVersionNuGet)" PrivateAssets="runtime" />
     <!-- Ensure .NET 4.7.2's System.Net.Http is used not the one from this NuGet package -->
-    <PackageReference Include="System.Net.Http" Version="4.3.3" ExcludeAssets="all" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" ExcludeAssets="all" />
     <!-- Ensure .NET 4.7.2's System.IO.Compression is used not the one from this NuGet package -->
     <PackageReference Include="System.IO.Compression" Version="4.3.0" ExcludeAssets="all" />
     <IncludeCopyLocal Include="Lucene.Net.dll" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -102,7 +102,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NuGetVersionNewtonsoftJson)" PrivateAssets="runtime" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" PrivateAssets="runtime" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.7" PrivateAssets="runtime,build" />
-    <PackageReference Include="StreamJsonRpc" Version="1.5.43" PrivateAssets="runtime" />
+    <PackageReference Include="StreamJsonRpc" Version="1.5.68" PrivateAssets="runtime" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" PrivateAssets="runtime" />
     <!-- remove this as it conflicts with the one in mscorlib. mono bug? -->
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" ExcludeAssets="all" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -85,7 +85,7 @@
     <!-- disable this for now, it's absurdly noisy
     <PackageReference Include="ClrHeapAllocationAnalyzer" Version="1.0.0.9" />
     -->
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.1.2" PrivateAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(NuGetVersionRoslyn)" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(NuGetVersionRoslyn)" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" PrivateAssets="runtime" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -100,15 +100,15 @@
     <PackageReference Include="Mono.Cecil" Version="$(NuGetVersionCecil)" PrivateAssets="runtime" />
     <PackageReference Include="MonoDevelopDev.Analyzers" Version="$(NuGetVersionMonoDevelopAnalyzers)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NuGetVersionNewtonsoftJson)" PrivateAssets="runtime" />
-    <PackageReference Include="SharpZipLib" Version="1.2.0" PrivateAssets="runtime" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.12" PrivateAssets="runtime,build" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" PrivateAssets="runtime" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.7" PrivateAssets="runtime,build" />
     <PackageReference Include="StreamJsonRpc" Version="1.5.43" PrivateAssets="runtime" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" PrivateAssets="runtime" />
     <!-- remove this as it conflicts with the one in mscorlib. mono bug? -->
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" ExcludeAssets="all" />
     <!-- update this to a version that doesn't crash -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.3.52" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="3.0.0-preview9.19423.4" PrivateAssets="runtime" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.0" PrivateAssets="runtime" />
   </ItemGroup>
   <ItemGroup>
     <IncludeCopyLocal Include="Humanizer.dll" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="$(NuGetVersionMicrosoftTemplateEngine)" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(NuGetVersionMicrosoftTemplateEngine)" PrivateAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="1.1.20180503.2" PrivateAssets="runtime" />
-    <PackageReference Include="YamlDotNet" Version="5.4.0" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
   <ItemGroup>
     <IncludeCopyLocal Include="ICSharpCode.NRefactory.Cecil.dll" />


### PR DESCRIPTION
This PR updated some nuget package versions
Some packages can't be updated to the latest version, because of compile errors. But it is a good idea to update them to the latest version where Dotdevelop can be compiled and run.
**Packages not updated to the latest version:**
Mono.Cecil from 0.10.1 to 0.10.4
Microsoft.TemplateEngine.Edge from 3.0.0-rc1.19464.2 to 5.0.403
Microsoft.TemplateEngine.Orchestrator.RunnableProjects from 3.0.0-rc1.19464.2 to 5.0.403
Microsoft.TestPlatform from 16.2.0 to 16.11.0
StreamJsonRpc from 1.5.43 to 1.5.68

**versions not to be updated in this PR:**

MonoDevelopDev.Analyzers cant be found on nuget.org website

ErrorProne.NET.Structs not tested, because newer versions are beta ones

NuGetVersionNuGet

NuGetVersionRoslyn

Microsoft.VisualStudio.Threading.Analyzers

the Visual Studio things, because this nuget packages are only used on windows for build and should be also compiled from source if possible like the linux ones or removed where no source code is avilable.

NuGetVersionVSEditor


Tested and Dotdevelop can be built and run from source with make on Linux. @gluckez, can this be reviewed?